### PR TITLE
Added flag to show `AppOpenAd` on new activity launched

### DIFF
--- a/ceres-ads/api/ceres-ads.api
+++ b/ceres-ads/api/ceres-ads.api
@@ -61,6 +61,7 @@ public final class dev/teogor/ceres/ads/AdView : androidx/appcompat/widget/AppCo
 
 public final class dev/teogor/ceres/ads/AdsExt {
 	public static final fun isAdActivity (Landroid/app/Activity;)Z
+	public static final fun showAppOpenAd (Landroid/content/Intent;)V
 }
 
 public final class dev/teogor/ceres/ads/AdsModule : dev/teogor/ceres/core/app/ModuleProvider {
@@ -211,6 +212,7 @@ public final class dev/teogor/ceres/ads/startup/AdsProvider : android/app/Applic
 	public fun onActivitySaveInstanceState (Landroid/app/Activity;Landroid/os/Bundle;)V
 	public fun onActivityStarted (Landroid/app/Activity;)V
 	public fun onActivityStopped (Landroid/app/Activity;)V
+	public fun onStart (Landroidx/lifecycle/LifecycleOwner;)V
 }
 
 public final class dev/teogor/ceres/ads/startup/AdsStartUp {
@@ -230,6 +232,7 @@ public final class dev/teogor/ceres/ads/startup/ProcessInitializer : com/zeoflow
 
 public final class dev/teogor/ceres/ads/utils/Constants {
 	public static final field AD_ACTIVITY_CLASS Ljava/lang/String;
+	public static final field FORCE_SHOW_APP_OPEN_AD Ljava/lang/String;
 	public static final field INSTANCE Ldev/teogor/ceres/ads/utils/Constants;
 	public static final field LOG_TAG Ljava/lang/String;
 	public static final field NOT_SET Ljava/lang/String;

--- a/ceres-ads/api/ceres-ads.api
+++ b/ceres-ads/api/ceres-ads.api
@@ -59,6 +59,10 @@ public final class dev/teogor/ceres/ads/AdView : androidx/appcompat/widget/AppCo
 	public final fun setColor (I)V
 }
 
+public final class dev/teogor/ceres/ads/AdsExt {
+	public static final fun isAdActivity (Landroid/app/Activity;)Z
+}
+
 public final class dev/teogor/ceres/ads/AdsModule : dev/teogor/ceres/core/app/ModuleProvider {
 	public fun <init> ()V
 	public fun onCreate ()V
@@ -241,10 +245,6 @@ public final class dev/teogor/ceres/ads/utils/Constants$TestAdsId {
 	public static final field NATIVE_VIDEO Ljava/lang/String;
 	public static final field REWARDED Ljava/lang/String;
 	public static final field REWARDED_INTERSTITIAL Ljava/lang/String;
-}
-
-public final class dev/teogor/ceres/ads/utils/ExtensionsKt {
-	public static final fun isAdActivity (Landroid/app/Activity;)Z
 }
 
 public final class dev/teogor/ceres/ads/utils/SystemKt {

--- a/ceres-ads/src/main/kotlin/dev/teogor/ceres/ads/AdsExt.kt
+++ b/ceres-ads/src/main/kotlin/dev/teogor/ceres/ads/AdsExt.kt
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-package dev.teogor.ceres.ads.utils
+@file:JvmName("AdsExt")
+
+package dev.teogor.ceres.ads
 
 import android.app.Activity
+import dev.teogor.ceres.ads.utils.Constants
 
 fun Activity.isAdActivity(): Boolean {
   return this.javaClass.canonicalName == Constants.AD_ACTIVITY_CLASS

--- a/ceres-ads/src/main/kotlin/dev/teogor/ceres/ads/AdsExt.kt
+++ b/ceres-ads/src/main/kotlin/dev/teogor/ceres/ads/AdsExt.kt
@@ -19,8 +19,14 @@
 package dev.teogor.ceres.ads
 
 import android.app.Activity
+import android.content.Intent
 import dev.teogor.ceres.ads.utils.Constants
+import dev.teogor.ceres.ads.utils.Constants.FORCE_SHOW_APP_OPEN_AD
 
 fun Activity.isAdActivity(): Boolean {
   return this.javaClass.canonicalName == Constants.AD_ACTIVITY_CLASS
+}
+
+fun Intent.showAppOpenAd() {
+  putExtra(FORCE_SHOW_APP_OPEN_AD, true)
 }

--- a/ceres-ads/src/main/kotlin/dev/teogor/ceres/ads/formats/AppOpenAd.kt
+++ b/ceres-ads/src/main/kotlin/dev/teogor/ceres/ads/formats/AppOpenAd.kt
@@ -23,7 +23,7 @@ import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.appopen.AppOpenAd
 import dev.teogor.ceres.ads.Ad
 import dev.teogor.ceres.ads.AdEvent
-import dev.teogor.ceres.ads.utils.isAdActivity
+import dev.teogor.ceres.ads.isAdActivity
 import dev.teogor.ceres.core.global.GlobalData
 
 abstract class AppOpenAd : Ad() {

--- a/ceres-ads/src/main/kotlin/dev/teogor/ceres/ads/formats/InterstitialAd.kt
+++ b/ceres-ads/src/main/kotlin/dev/teogor/ceres/ads/formats/InterstitialAd.kt
@@ -24,7 +24,7 @@ import com.google.android.gms.ads.interstitial.InterstitialAd
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
 import dev.teogor.ceres.ads.Ad
 import dev.teogor.ceres.ads.AdEvent
-import dev.teogor.ceres.ads.utils.isAdActivity
+import dev.teogor.ceres.ads.isAdActivity
 import dev.teogor.ceres.core.global.GlobalData
 
 abstract class InterstitialAd : Ad() {

--- a/ceres-ads/src/main/kotlin/dev/teogor/ceres/ads/startup/AdsProvider.kt
+++ b/ceres-ads/src/main/kotlin/dev/teogor/ceres/ads/startup/AdsProvider.kt
@@ -21,6 +21,7 @@ import android.app.Application
 import android.os.Bundle
 import android.util.Log
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.android.gms.ads.MobileAds
 import com.google.android.gms.ads.RequestConfiguration
@@ -30,6 +31,7 @@ import dev.teogor.ceres.ads.utils.Constants
 import dev.teogor.ceres.core.construct.AppData
 import dev.teogor.ceres.core.logger.Logger
 import dev.teogor.ceres.core.util.AppUtils
+import dev.teogor.ceres.extensions.extrasBoolean
 
 /**
  * fixme Interstitials that show when your app is in the background are a
@@ -85,7 +87,14 @@ class AdsProvider constructor(application: Application) :
   }
 
   override fun onActivityStarted(activity: Activity) {
-    showAd()
+    activity.extrasBoolean(
+      key = Constants.FORCE_SHOW_APP_OPEN_AD
+    ) {
+      if (this) {
+        log("Showing AppOpenAd because it's intent was flagged with showAppOpenAd()")
+        showAd()
+      }
+    }
   }
 
   override fun onActivityResumed(activity: Activity) {
@@ -101,6 +110,12 @@ class AdsProvider constructor(application: Application) :
   }
 
   override fun onActivityDestroyed(activity: Activity) {
+  }
+
+  /** LifecycleObserver method that shows the app open ad when the app moves to foreground. */
+  override fun onStart(owner: LifecycleOwner) {
+    super.onStart(owner)
+    showAd()
   }
 
   private fun showAd() {

--- a/ceres-ads/src/main/kotlin/dev/teogor/ceres/ads/utils/Constants.kt
+++ b/ceres-ads/src/main/kotlin/dev/teogor/ceres/ads/utils/Constants.kt
@@ -22,6 +22,8 @@ object Constants {
   const val NOT_SET = "not_set"
   const val AD_ACTIVITY_CLASS = "com.google.android.gms.ads.AdActivity"
 
+  const val FORCE_SHOW_APP_OPEN_AD = "force_show_app_open_ad"
+
   object TestAdsId {
     const val APP_OPEN = "ca-app-pub-3940256099942544/3419835294"
     const val BANNER = "ca-app-pub-3940256099942544/6300978111"

--- a/ceres-extensions/api/ceres-extensions.api
+++ b/ceres-extensions/api/ceres-extensions.api
@@ -1,5 +1,9 @@
 public final class dev/teogor/ceres/extensions/ActivityExtKt {
+	public static final fun extrasBoolean (Landroid/app/Activity;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun extrasBoolean$default (Landroid/app/Activity;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun findNavController (Landroidx/fragment/app/FragmentActivity;I)Landroidx/navigation/NavController;
+	public static final fun hasIntentExtras (Landroid/app/Activity;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun hasIntentExtras$default (Landroid/app/Activity;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class dev/teogor/ceres/extensions/ApplicationExtKt {

--- a/ceres-extensions/src/main/kotlin/dev/teogor/ceres/extensions/ActivityExt.kt
+++ b/ceres-extensions/src/main/kotlin/dev/teogor/ceres/extensions/ActivityExt.kt
@@ -16,6 +16,8 @@
 
 package dev.teogor.ceres.extensions
 
+import android.app.Activity
+import android.os.Bundle
 import androidx.annotation.IdRes
 import androidx.fragment.app.FragmentActivity
 import androidx.navigation.NavController
@@ -29,5 +31,25 @@ fun FragmentActivity.findNavController(
     navHostFragment.navController
   } else {
     null
+  }
+}
+
+fun Activity.hasIntentExtras(
+  extrasRun: Bundle.() -> Unit = {}
+) {
+  this.intent.extras?.let {
+    extrasRun(it)
+  }
+}
+
+fun Activity.extrasBoolean(
+  key: String,
+  defaultValue: Boolean = false,
+  extrasRun: Boolean.() -> Unit = {}
+) {
+  this.hasIntentExtras {
+    getBoolean(key, defaultValue).apply {
+      extrasRun()
+    }
   }
 }


### PR DESCRIPTION
## Guidelines

Added flag to show `AppOpenAd` on new activity launched

To flag an `activity` to show the AppOpenAd call `showAppOpenAd()` on its intent

closes #55 

### Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

### Preparing a pull request for review

Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.