### PR TITLE
Enhancement: Optional Status Bar Padding in `FullScreenLayoutBase`

### DIFF
--- a/screen/core/api/core.api
+++ b/screen/core/api/core.api
@@ -13,7 +13,7 @@ public final class dev/teogor/ceres/screen/core/layout/ColumnLayoutBaseKt {
 }
 
 public final class dev/teogor/ceres/screen/core/layout/FullScreenLayoutBaseKt {
-	public static final fun FullScreenLayoutBase-3IgeMak (Ljava/lang/String;JLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun FullScreenLayoutBase-sW7UJKQ (Ljava/lang/String;JZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class dev/teogor/ceres/screen/core/layout/LazyColumnLayoutBaseKt {

--- a/screen/core/src/main/kotlin/dev/teogor/ceres/screen/core/layout/FullScreenLayoutBase.kt
+++ b/screen/core/src/main/kotlin/dev/teogor/ceres/screen/core/layout/FullScreenLayoutBase.kt
@@ -31,13 +31,18 @@ import dev.teogor.ceres.ui.theme.MaterialTheme
 fun FullScreenLayoutBase(
   screenName: String? = null,
   backgroundColor: Color = MaterialTheme.colorScheme.background,
+  hasStatusBar: Boolean = false,
   content: @Composable BoxScope.() -> Unit,
 ) {
   Box(
     modifier = Modifier
       .fillMaxSize()
       .background(color = backgroundColor)
-      .statusBarsPadding(),
+      .apply {
+        if (hasStatusBar) {
+          statusBarsPadding()
+        }
+      },
     content = content,
   )
 


### PR DESCRIPTION
With this update, users can now decide whether they want to add status bar padding or not by setting the `hasStatusBar` parameter when using the `FullScreenLayoutBase` function.

Here's an example of how to use it:

```kotlin
// Add status bar padding
FullScreenLayoutBase(
  screenName = "YourScreenName",
  backgroundColor = Color.White, // Background color
  hasStatusBar = true, // Add status bar padding
) {
  // Your content here
}

// Without status bar padding
FullScreenLayoutBase(
  screenName = "YourScreenName",
  backgroundColor = Color.White, // Background color
  hasStatusBar = false, // Do not add status bar padding
) {
  // Your content here
}
```

This enhancement provides users with greater control over their app's layout and allows them to tailor the status bar padding according to their specific needs. Please review and test the changes, and feel free to provide feedback.

closes #106 