### PR TITLE
Update Android SDK and Introduce Core Library Desugaring Control

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -47,3 +47,7 @@ android.suppressUnsupportedCompileSdk=34
 
 # When enabled, advanced flavours are added, affecting the CeresFlavor enum.
 ceres.buildfeatures.flavours=false
+ceres.buildfeatures.sdk.min=24
+ceres.buildfeatures.sdk.compile=34
+ceres.buildfeatures.sdk.target=34
+ceres.buildfeatures.desugaring.enabled=true

--- a/plugin/library-convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/plugin/library-convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -19,6 +19,7 @@ import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import dev.teogor.ceres.configureGradleManagedDevices
 import dev.teogor.ceres.configureKotlinAndroid
 import dev.teogor.ceres.configurePrintApksTask
+import dev.teogor.ceres.utils.getIntProperty
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -33,7 +34,10 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
       extensions.configure<ApplicationExtension> {
         configureKotlinAndroid(this)
-        defaultConfig.targetSdk = 34
+        defaultConfig.targetSdk = getIntProperty(
+          key = "ceres.buildfeatures.sdk.target",
+          defaultValue = 34,
+        )
         configureGradleManagedDevices(this)
       }
       extensions.configure<ApplicationAndroidComponentsExtension> {

--- a/plugin/library-convention/src/main/kotlin/dev/teogor/ceres/KotlinAndroid.kt
+++ b/plugin/library-convention/src/main/kotlin/dev/teogor/ceres/KotlinAndroid.kt
@@ -17,6 +17,8 @@
 package dev.teogor.ceres
 
 import com.android.build.api.dsl.CommonExtension
+import dev.teogor.ceres.utils.getBooleanProperty
+import dev.teogor.ceres.utils.getIntProperty
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
@@ -32,11 +34,18 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 internal fun Project.configureKotlinAndroid(
   commonExtension: CommonExtension<*, *, *, *, *>,
 ) {
+
   commonExtension.apply {
-    compileSdk = 34
+    compileSdk = getIntProperty(
+      key = "ceres.buildfeatures.sdk.compile",
+      defaultValue = 34,
+    )
 
     defaultConfig {
-      minSdk = 21
+      minSdk = getIntProperty(
+        key = "ceres.buildfeatures.sdk.min",
+        defaultValue = 21,
+      )
     }
 
     compileOptions {
@@ -44,7 +53,11 @@ internal fun Project.configureKotlinAndroid(
       // https://developer.android.com/studio/write/java11-minimal-support-table
       sourceCompatibility = JavaVersion.VERSION_11
       targetCompatibility = JavaVersion.VERSION_11
-      isCoreLibraryDesugaringEnabled = true
+
+      isCoreLibraryDesugaringEnabled = getBooleanProperty(
+        key = "ceres.buildfeatures.desugaring.enabled",
+        defaultValue = true,
+      )
     }
   }
 
@@ -69,6 +82,12 @@ internal fun Project.configureKotlinAndroid(
   val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
   dependencies {
-    add("coreLibraryDesugaring", libs.findLibrary("android.desugarJdkLibs").get())
+    if (getBooleanProperty(
+        key = "ceres.buildfeatures.desugaring.enabled",
+        defaultValue = true,
+      )
+    ) {
+      add("coreLibraryDesugaring", libs.findLibrary("android.desugarJdkLibs").get())
+    }
   }
 }


### PR DESCRIPTION
This pull request focuses on updating the Android SDK versions and introduces the ability to control core library desugaring as a build feature. These changes align the project's configuration with the specified SDK versions and provide flexibility in enabling or disabling core library desugaring.

Key Changes:
- Updated `minSdk`, `compileSdk`, and `targetSdk` versions based on provided properties.
- Added support for enabling or disabling core library desugaring as a build feature, controlled by the `ceres.buildfeatures.desugaring.enabled` property.

Use case:
```properties
# Edit the minimum SDK version
ceres.buildfeatures.sdk.min=24

# Edit the compile SDK version
ceres.buildfeatures.sdk.compile=34

# Edit the target SDK version
ceres.buildfeatures.sdk.target=34

# Enable or disable core library desugaring
ceres.buildfeatures.desugaring.enabled=true
```

closes #104 
closes #105 