### PR TITLE
Fix: Remove 'about-libraries' Plugin Configuration

### DIFF
--- a/screen/ui/build.gradle.kts
+++ b/screen/ui/build.gradle.kts
@@ -17,9 +17,6 @@ plugins {
   id("dev.teogor.ceres.android.library")
   id("dev.teogor.ceres.android.library.compose")
   id("dev.teogor.ceres.android.library.jacoco")
-
-  // Feature :: About
-  alias(libs.plugins.about.libraries) apply true
 }
 
 android {


### PR DESCRIPTION
This pull request addresses the reported issue related to the 'ceres-screen-ui' library's 'about-libraries' plugin configuration. The current configuration bundles these elements, responsible for generating the 'aboutlibraries.json' file, within the library itself. However, it is more appropriate for users to declare these elements in their own projects.

Key Changes:
- Removed the 'about-libraries' plugin configuration from the 'ceres-screen-ui' library's build.gradle.kts file.
- Updated the documentation to provide clear guidance to users on how to declare the 'about-libraries' plugin configuration in their own project's build.gradle.kts file.
- Emphasized the importance of allowing users to control these elements for generating the 'aboutlibraries.json' file in their projects.

closes #107 