### PR TITLE
Documentation Update to Match Ceres Plugins Version 1.0.0-alpha02

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Overview
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Maven Central](https://img.shields.io/maven-central/v/dev.teogor.ceres/bom.svg?label=Maven%20Central)](https://central.sonatype.com/search?q=g%3Adev.teogor.ceres+a%3Abom&smo=true)
-[![API](https://img.shields.io/badge/API-21%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=21)
+[![API](https://img.shields.io/badge/API-21%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=24)
 [![Profile](https://source.teogor.dev/badges/teogor-github.svg)](https://github.com/teogor)
 [![Portfolio](https://source.teogor.dev/badges/teogor-dev.svg)](https://teogor.dev)
 
@@ -39,7 +39,7 @@ To streamline the implementation of Ceres libraries, use the following Gradle se
 
 ```kotlin
 dependencies {
-  implementation(platform("dev.teogor.ceres:bom:1.0.0-alpha01"))
+  implementation(platform("dev.teogor.ceres:bom:1.0.0-alpha02"))
 }
 ```
 
@@ -48,7 +48,7 @@ dependencies {
 ```kotlin
 dependencies {
   // Ceres BoM
-  implementation(platform("dev.teogor.ceres:bom:1.0.0-alpha01"))
+  implementation(platform("dev.teogor.ceres:bom:1.0.0-alpha02"))
 
   // Include individual Ceres libraries here as needed
   implementation("dev.teogor.ceres:backup-core")

--- a/plugin/library-convention/build.gradle.kts
+++ b/plugin/library-convention/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "dev.teogor.ceres.plugin"
-version = "1.0.0-alpha01"
+version = "1.0.0-alpha02"
 
 java {
   // Up to Java 11 APIs are available through desugaring


### PR DESCRIPTION
This PR updates the documentation to align with the Ceres Plugins version 1.0.0-alpha02. It includes the following changes:

- Updated documentation content to reflect the latest features, changes, and usage instructions specific to Ceres Plugins version 1.0.0-alpha02.
- Ensured consistency between code and documentation.
- Improved clarity and accuracy of documentation sections.