### PR TITLE
Feature: Enhance Compose Modifier with Conditional Application

### DIFF
--- a/ui/foundation/api/foundation.api
+++ b/ui/foundation/api/foundation.api
@@ -1,4 +1,5 @@
 public final class dev/teogor/ceres/ui/foundation/ModifierExtensionsKt {
+	public static final fun applyIf (Landroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/Modifier;
 	public static final fun clickable-GK2WfCU (Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/foundation/Indication;ZLjava/lang/String;Landroidx/compose/ui/semantics/Role;ILkotlin/jvm/functions/Function0;)Landroidx/compose/ui/Modifier;
 	public static synthetic fun clickable-GK2WfCU$default (Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/foundation/Indication;ZLjava/lang/String;Landroidx/compose/ui/semantics/Role;ILkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 	public static final fun clickable-oSLSa3U (Landroidx/compose/ui/Modifier;ZLjava/lang/String;Landroidx/compose/ui/semantics/Role;ILkotlin/jvm/functions/Function0;)Landroidx/compose/ui/Modifier;

--- a/ui/foundation/src/main/kotlin/dev/teogor/ceres/ui/foundation/ModifierExtensions.kt
+++ b/ui/foundation/src/main/kotlin/dev/teogor/ceres/ui/foundation/ModifierExtensions.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -134,5 +135,14 @@ fun Modifier.sideClickable(
       val isLeft = offset.x < centerX
       onClick(isLeft)
     }
+  }
+}
+
+@Composable
+fun Modifier.applyIf(condition: Boolean, block: @Composable Modifier.() -> Modifier): Modifier {
+  return if (condition) {
+    this
+  } else {
+    this.block()
   }
 }


### PR DESCRIPTION
This pull request introduces an enhancement to the Compose Modifier, allowing for conditional application based on a specified condition. The new `applyIf` extension function provides a more flexible way to apply modifiers conditionally within Compose functions.

**Commit Details:**
- Added the `applyIf` extension function to the `Modifier` class.
- The `applyIf` function conditionally applies the provided block of modifiers based on the specified condition.
- The `applyIf` function enhances the flexibility of Compose Modifier usage, enabling more dynamic UI compositions.

**Example Usage:**
```kotlin
// Apply a modifier only if the condition is met
modifier.applyIf(condition) {
    offset(30f)
    clickable {}
}
```