### PR TITLE
Fix Full-Screen Layout Status Bar Padding Issue

### DIFF
--- a/screen/core/src/main/kotlin/dev/teogor/ceres/screen/core/layout/FullScreenLayoutBase.kt
+++ b/screen/core/src/main/kotlin/dev/teogor/ceres/screen/core/layout/FullScreenLayoutBase.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import dev.teogor.ceres.navigation.events.TrackScreenViewEvent
+import dev.teogor.ceres.ui.foundation.applyIf
 import dev.teogor.ceres.ui.theme.MaterialTheme
 
 @Composable
@@ -38,10 +39,8 @@ fun FullScreenLayoutBase(
     modifier = Modifier
       .fillMaxSize()
       .background(color = backgroundColor)
-      .apply {
-        if (hasStatusBar) {
-          statusBarsPadding()
-        }
+      .applyIf(hasStatusBar) {
+        Modifier.statusBarsPadding()
       },
     content = content,
   )

--- a/ui/foundation/api/foundation.api
+++ b/ui/foundation/api/foundation.api
@@ -1,5 +1,5 @@
 public final class dev/teogor/ceres/ui/foundation/ModifierExtensionsKt {
-	public static final fun applyIf (Landroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/Modifier;
+	public static final fun applyIf (Landroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
 	public static final fun clickable-GK2WfCU (Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/foundation/Indication;ZLjava/lang/String;Landroidx/compose/ui/semantics/Role;ILkotlin/jvm/functions/Function0;)Landroidx/compose/ui/Modifier;
 	public static synthetic fun clickable-GK2WfCU$default (Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/foundation/Indication;ZLjava/lang/String;Landroidx/compose/ui/semantics/Role;ILkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 	public static final fun clickable-oSLSa3U (Landroidx/compose/ui/Modifier;ZLjava/lang/String;Landroidx/compose/ui/semantics/Role;ILkotlin/jvm/functions/Function0;)Landroidx/compose/ui/Modifier;

--- a/ui/foundation/src/main/kotlin/dev/teogor/ceres/ui/foundation/ModifierExtensions.kt
+++ b/ui/foundation/src/main/kotlin/dev/teogor/ceres/ui/foundation/ModifierExtensions.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material.ripple.rememberRipple
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -138,11 +137,10 @@ fun Modifier.sideClickable(
   }
 }
 
-@Composable
-fun Modifier.applyIf(condition: Boolean, block: @Composable Modifier.() -> Modifier): Modifier {
+fun Modifier.applyIf(condition: Boolean, block: Modifier.() -> Modifier): Modifier {
   return if (condition) {
-    this
+    this.then(block())
   } else {
-    this.block()
+    this
   }
 }


### PR DESCRIPTION
This pull request addresses an issue with the status bar padding in full-screen layouts. Previously, the status bar padding was not being applied correctly in certain cases. To fix this issue, I've made the following changes:

- Refactored the `applyIf` extension function to correctly apply modifiers conditionally.
- Ensured that status bar padding is applied appropriately when needed.
- Removed commented-out code for clarity.

These changes resolve the issue and ensure that the status bar padding behaves as expected in full-screen layouts.

closes #119 