### PR TITLE
Add Onboarding Screen for Improved User Experience

### DIFF
--- a/app/src/main/kotlin/dev/teogor/ceres/feature/onboarding/OnboardingNavigation.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/feature/onboarding/OnboardingNavigation.kt
@@ -27,6 +27,7 @@ import dev.teogor.ceres.screen.ui.onboarding.onboardingNavPath
 @OptIn(ExperimentalOnboardingScreenApi::class)
 fun NavGraphBuilder.onboardingScreenNav(
   baseActions: BaseActions,
+  adsConsentOnly: Boolean,
 ) = onboardingNavPath(
   baseActions = baseActions,
   onboardingData = OnboardingScreenData(
@@ -36,9 +37,15 @@ fun NavGraphBuilder.onboardingScreenNav(
     termsOfServiceLink = "https://terms.teogor.dev",
   ),
   endRoute = HomeScreenConfig,
-  screens = listOf(
-    OnboardingScreen.INTRO,
-    OnboardingScreen.LEGAL,
-    OnboardingScreen.AD_CHOICES,
-  ),
+  screens = if (adsConsentOnly) {
+    listOf(
+      OnboardingScreen.AD_CHOICES,
+    )
+  } else {
+    listOf(
+      OnboardingScreen.INTRO,
+      OnboardingScreen.LEGAL,
+      OnboardingScreen.AD_CHOICES,
+    )
+  },
 )

--- a/app/src/main/kotlin/dev/teogor/ceres/feature/onboarding/OnboardingNavigation.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/feature/onboarding/OnboardingNavigation.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.feature.onboarding
+
+import androidx.navigation.NavGraphBuilder
+import dev.teogor.ceres.feature.home.HomeScreenConfig
+import dev.teogor.ceres.framework.core.app.BaseActions
+import dev.teogor.ceres.screen.ui.api.ExperimentalOnboardingScreenApi
+import dev.teogor.ceres.screen.ui.onboarding.OnboardingScreenData
+import dev.teogor.ceres.screen.ui.onboarding.model.OnboardingScreen
+import dev.teogor.ceres.screen.ui.onboarding.onboardingNavPath
+
+@OptIn(ExperimentalOnboardingScreenApi::class)
+fun NavGraphBuilder.onboardingScreenNav(
+  baseActions: BaseActions,
+) = onboardingNavPath(
+  baseActions = baseActions,
+  onboardingData = OnboardingScreenData(
+    appName = "Ceres",
+    supportEmail = "open-source@teogor.dev",
+    privacyPolicyLink = "https://privacy.teogor.dev",
+    termsOfServiceLink = "https://terms.teogor.dev",
+  ),
+  endRoute = HomeScreenConfig,
+  screens = listOf(
+    OnboardingScreen.INTRO,
+    OnboardingScreen.LEGAL,
+    OnboardingScreen.AD_CHOICES,
+  ),
+)

--- a/app/src/main/kotlin/dev/teogor/ceres/navigation/Navigation.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/navigation/Navigation.kt
@@ -18,6 +18,8 @@ package dev.teogor.ceres.navigation
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import dev.teogor.ceres.data.datastore.defaults.ceresPreferences
 import dev.teogor.ceres.feature.about.aboutScreenNav
@@ -29,6 +31,8 @@ import dev.teogor.ceres.feature.settings.settingsScreenNav
 import dev.teogor.ceres.framework.core.app.BaseActions
 import dev.teogor.ceres.framework.core.app.CeresAppState
 import dev.teogor.ceres.framework.core.model.NavGraphOptions
+import dev.teogor.ceres.monetisation.ads.ExperimentalAdsControlApi
+import dev.teogor.ceres.monetisation.ads.LocalAdsControl
 import dev.teogor.ceres.navigation.core.NavHost
 import dev.teogor.ceres.screen.ui.about.aboutGraphNav
 import dev.teogor.ceres.screen.ui.api.ExperimentalOnboardingScreenApi
@@ -59,7 +63,7 @@ fun NavGraphOptions.ApplyNavHost() = NavHost(
  * @param appState The Ceres app state.
  * @param baseActions The base actions for navigation.
  */
-@OptIn(ExperimentalOnboardingScreenApi::class)
+@OptIn(ExperimentalOnboardingScreenApi::class, ExperimentalAdsControlApi::class)
 @Composable
 private fun NavHost(
   modifier: Modifier = Modifier,
@@ -67,7 +71,9 @@ private fun NavHost(
   baseActions: BaseActions,
 ) {
   val onboardingCompleted = ceresPreferences().onboardingComplete
-  val startDestination = if (onboardingCompleted) {
+  val adsControl = LocalAdsControl.current
+  val canRequestAds by remember { adsControl.canRequestAds }
+  val startDestination = if (onboardingCompleted && canRequestAds) {
     HomeScreenConfig
   } else {
     OnboardingRoute
@@ -78,7 +84,10 @@ private fun NavHost(
     modifier = modifier,
     startDestination = startDestination,
   ) {
-    onboardingScreenNav(baseActions)
+    onboardingScreenNav(
+      baseActions = baseActions,
+      adsConsentOnly = !canRequestAds && onboardingCompleted,
+    )
 
     homeScreenNav(baseActions)
 

--- a/app/src/main/kotlin/dev/teogor/ceres/navigation/Navigation.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/navigation/Navigation.kt
@@ -19,16 +19,20 @@ package dev.teogor.ceres.navigation
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import dev.teogor.ceres.data.datastore.defaults.ceresPreferences
 import dev.teogor.ceres.feature.about.aboutScreenNav
-import dev.teogor.ceres.feature.home.homeNavigationRoute
+import dev.teogor.ceres.feature.home.HomeScreenConfig
 import dev.teogor.ceres.feature.home.homeScreenNav
 import dev.teogor.ceres.feature.lookandfeel.lookAndFeelScreenNav
+import dev.teogor.ceres.feature.onboarding.onboardingScreenNav
 import dev.teogor.ceres.feature.settings.settingsScreenNav
 import dev.teogor.ceres.framework.core.app.BaseActions
 import dev.teogor.ceres.framework.core.app.CeresAppState
 import dev.teogor.ceres.framework.core.model.NavGraphOptions
 import dev.teogor.ceres.navigation.core.NavHost
 import dev.teogor.ceres.screen.ui.about.aboutGraphNav
+import dev.teogor.ceres.screen.ui.api.ExperimentalOnboardingScreenApi
+import dev.teogor.ceres.screen.ui.onboarding.OnboardingRoute
 import dev.teogor.ceres.screen.ui.settings.settingsGraphNav
 import dev.teogor.ceres.screen.ui.userprefs.userPreferencesScreenNav
 
@@ -52,22 +56,30 @@ fun NavGraphOptions.ApplyNavHost() = NavHost(
  * Composable function for defining a [NavHost] with customizable parameters.
  *
  * @param modifier The modifier for the [NavHost].
- * @param startDestination The start destination route.
  * @param appState The Ceres app state.
  * @param baseActions The base actions for navigation.
  */
+@OptIn(ExperimentalOnboardingScreenApi::class)
 @Composable
 private fun NavHost(
   modifier: Modifier = Modifier,
-  startDestination: String = homeNavigationRoute,
   appState: CeresAppState,
   baseActions: BaseActions,
 ) {
+  val onboardingCompleted = ceresPreferences().onboardingComplete
+  val startDestination = if (onboardingCompleted) {
+    HomeScreenConfig
+  } else {
+    OnboardingRoute
+  }.route
+
   NavHost(
     navController = appState.navController,
     modifier = modifier,
     startDestination = startDestination,
   ) {
+    onboardingScreenNav(baseActions)
+
     homeScreenNav(baseActions)
 
     userPreferencesScreenNav(baseActions)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 apiValidator = "0.13.2"
 aboutLibraries = "10.8.3"
-accompanist = "0.33.1-alpha"
+accompanist = "0.33.2-alpha"
 androidDesugarJdkLibs = "2.0.3"
 androidGradlePlugin = "8.1.1"
 androidxActivity = "1.8.0-rc01"
@@ -73,6 +73,7 @@ vanniktechMavenPlugin = "0.25.3"
 [libraries]
 about-libraries-core = { group = "com.mikepenz", name = "aboutlibraries-core", version.ref = "aboutLibraries" }
 accompanist-testharness = { group = "com.google.accompanist", name = "accompanist-testharness", version.ref = "accompanist" }
+accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist" }
 android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }

--- a/monetisation/ads/api/ads.api
+++ b/monetisation/ads/api/ads.api
@@ -2,9 +2,12 @@ public abstract interface class dev/teogor/ceres/monetisation/ads/AdsControl {
 	public abstract fun getCanRequestAds ()Landroidx/compose/runtime/MutableState;
 	public abstract fun getConsentRequirementStatus ()Landroidx/compose/runtime/MutableState;
 	public abstract fun getConsentStatus ()Landroidx/compose/runtime/MutableState;
+	public abstract fun showConsent ()V
 }
 
 public final class dev/teogor/ceres/monetisation/ads/AdsControlKt {
+	public static final fun HandleAdsConsent (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public static final fun getConsentIsShowing (Ldev/teogor/ceres/monetisation/ads/AdsControl;)Z
 	public static final fun getLocalAdsControl ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun getShouldShowConsentDialog (Ldev/teogor/ceres/monetisation/ads/AdsControl;)Z
 }
@@ -21,18 +24,21 @@ public final class dev/teogor/ceres/monetisation/ads/AdsControlProvider {
 public final class dev/teogor/ceres/monetisation/ads/AndroidAdsControl : dev/teogor/ceres/monetisation/ads/AdsControl {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;)V
-	public synthetic fun <init> (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Landroidx/compose/runtime/MutableState;
 	public final fun component2 ()Landroidx/compose/runtime/MutableState;
 	public final fun component3 ()Landroidx/compose/runtime/MutableState;
-	public final fun copy (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;)Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;ILjava/lang/Object;)Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;
+	public final fun component4 ()Lkotlin/jvm/functions/Function0;
+	public final fun copy (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;)Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCanRequestAds ()Landroidx/compose/runtime/MutableState;
 	public fun getConsentRequirementStatus ()Landroidx/compose/runtime/MutableState;
 	public fun getConsentStatus ()Landroidx/compose/runtime/MutableState;
+	public final fun getShowConsent ()Lkotlin/jvm/functions/Function0;
 	public fun hashCode ()I
+	public fun showConsent ()V
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/monetisation/messaging/src/main/kotlin/dev/teogor/ceres/monetisation/messaging/ConsentManager.kt
+++ b/monetisation/messaging/src/main/kotlin/dev/teogor/ceres/monetisation/messaging/ConsentManager.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalAdsControlApi::class)
-
 package dev.teogor.ceres.monetisation.messaging
 
 import android.app.Activity
@@ -57,9 +55,11 @@ object ConsentManager {
       }
     }
 
+  @OptIn(ExperimentalAdsControlApi::class)
   private val adsControl: AdsControl
     get() = AdsControlProvider.adsControl
 
+  @OptIn(ExperimentalAdsControlApi::class)
   fun loadAndShowConsentFormIfRequired() {
     activity?.let {
       adsControl.consentStatus.value = ConsentStatus.CONSENT_FORM_DISPLAYED
@@ -77,6 +77,7 @@ object ConsentManager {
     }
   }
 
+  @OptIn(ExperimentalAdsControlApi::class)
   fun resetConsent() {
     if (!::consentInformation.isInitialized) {
       return
@@ -88,6 +89,7 @@ object ConsentManager {
     }
   }
 
+  @OptIn(ExperimentalAdsControlApi::class)
   fun initialiseConsentForm(
     activity: Activity,
   ) {
@@ -128,6 +130,7 @@ object ConsentManager {
     }
   }
 
+  @OptIn(ExperimentalAdsControlApi::class)
   private fun onConsentInfoUpdateSuccess(
     activity: Activity,
   ) {

--- a/monetisation/messaging/src/main/kotlin/dev/teogor/ceres/monetisation/messaging/MessagingManager.kt
+++ b/monetisation/messaging/src/main/kotlin/dev/teogor/ceres/monetisation/messaging/MessagingManager.kt
@@ -32,9 +32,11 @@ class MessagingManager {
     @OptIn(ExperimentalAdsControlApi::class)
     fun initialize(context: Context) {
       AdMobInitializer.configureAdsControl(
-        AndroidAdsControl().apply {
-          canRequestAds.value = true
-        },
+        AndroidAdsControl(
+          showConsent = {
+            ConsentManager.loadAndShowConsentFormIfRequired()
+          },
+        ),
       )
 
       if (context is Application) {

--- a/screen/core/api/core.api
+++ b/screen/core/api/core.api
@@ -16,6 +16,10 @@ public final class dev/teogor/ceres/screen/core/layout/FullScreenLayoutBaseKt {
 	public static final fun FullScreenLayoutBase-sW7UJKQ (Ljava/lang/String;JZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class dev/teogor/ceres/screen/core/layout/LayoutWithBottomHeaderKt {
+	public static final fun LayoutWithBottomHeader-bbrV0mI (Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment$Horizontal;JFZZLjava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+}
+
 public final class dev/teogor/ceres/screen/core/layout/LazyColumnLayoutBaseKt {
 	public static final fun LazyColumnLayoutBase (Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/Arrangement$HorizontalOrVertical;ZZLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }

--- a/screen/core/src/main/kotlin/dev/teogor/ceres/screen/core/layout/LayoutWithBottomHeader.kt
+++ b/screen/core/src/main/kotlin/dev/teogor/ceres/screen/core/layout/LayoutWithBottomHeader.kt
@@ -1,0 +1,69 @@
+package dev.teogor.ceres.screen.core.layout
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import dev.teogor.ceres.navigation.events.TrackScreenViewEvent
+import dev.teogor.ceres.screen.core.attachScrollState
+import dev.teogor.ceres.screen.core.scope.ScreenListScope
+import dev.teogor.ceres.ui.designsystem.CeresBackground
+import dev.teogor.ceres.ui.designsystem.scrollbar.LazyColumnScrollbar
+import dev.teogor.ceres.ui.designsystem.scrollbar.ScrollbarCustomization
+
+@Composable
+fun LayoutWithBottomHeader(
+  bottomContent: @Composable ColumnScope.() -> Unit,
+  modifier: Modifier = Modifier,
+  horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+  color: Color = Color.Unspecified,
+  tonalElevation: Dp = Dp.Unspecified,
+  hasScrollbar: Boolean = true,
+  hasScrollbarBackground: Boolean = true,
+  screenName: String? = null,
+  content: ScreenListScope.() -> Unit,
+) {
+  val state = rememberLazyListState().attachScrollState()
+  CeresBackground(
+    color = color,
+    tonalElevation = tonalElevation,
+  ) {
+    Column(
+      modifier = Modifier.fillMaxSize(),
+    ) {
+      Box(
+        modifier = Modifier.weight(1f),
+      ) {
+        LazyColumnScrollbar(
+          scrollbarCustomization = ScrollbarCustomization(
+            state = state,
+          ).copy(
+            enabled = hasScrollbar && !(!state.canScrollForward && !state.canScrollBackward),
+            hasScrollbarBackground = hasScrollbarBackground,
+          ),
+        ) {
+          LazyColumn(
+            state = state,
+            modifier = modifier
+              .fillMaxSize(),
+            horizontalAlignment = horizontalAlignment,
+          ) {
+            content()
+          }
+        }
+      }
+      bottomContent()
+    }
+  }
+
+  screenName?.let {
+    TrackScreenViewEvent(screenName = it)
+  }
+}

--- a/screen/core/src/main/kotlin/dev/teogor/ceres/screen/core/layout/LayoutWithBottomHeader.kt
+++ b/screen/core/src/main/kotlin/dev/teogor/ceres/screen/core/layout/LayoutWithBottomHeader.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.teogor.ceres.screen.core.layout
 
 import androidx.compose.foundation.layout.Box

--- a/screen/ui/api/ui.api
+++ b/screen/ui/api/ui.api
@@ -129,6 +129,9 @@ public final class dev/teogor/ceres/screen/ui/about/libraries/util/StableLibrary
 	public final synthetic fun unbox-impl ()Lcom/mikepenz/aboutlibraries/entity/Library;
 }
 
+public abstract interface annotation class dev/teogor/ceres/screen/ui/api/ExperimentalOnboardingScreenApi : java/lang/annotation/Annotation {
+}
+
 public final class dev/teogor/ceres/screen/ui/components/HeaderSurfaceKt {
 	public static final fun HeaderSurface (Ljava/lang/String;Ldev/teogor/ceres/ui/foundation/graphics/Icon;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static final fun HeaderSurfaceBase (Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/layout/PaddingValues;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V

--- a/screen/ui/api/ui.api
+++ b/screen/ui/api/ui.api
@@ -180,6 +180,217 @@ public final class dev/teogor/ceres/screen/ui/lookandfeel/LookAndFeelScreenRoute
 	public fun getRoute ()Ljava/lang/String;
 }
 
+public final class dev/teogor/ceres/screen/ui/onboarding/AdChoicesRoute : dev/teogor/ceres/navigation/core/ScreenRoute {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/AdChoicesRoute;
+	public fun getRoute ()Ljava/lang/String;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/IntroRoute : dev/teogor/ceres/navigation/core/ScreenRoute {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/IntroRoute;
+	public fun getRoute ()Ljava/lang/String;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/LegalRoute : dev/teogor/ceres/navigation/core/ScreenRoute {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/LegalRoute;
+	public fun getRoute ()Ljava/lang/String;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/OnboardingNavigationKt {
+	public static final fun onboardingNavPath (Landroidx/navigation/NavGraphBuilder;Ldev/teogor/ceres/framework/core/app/BaseActions;Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;Ldev/teogor/ceres/navigation/core/ScreenRoute;Ljava/util/List;)V
+	public static synthetic fun onboardingNavPath$default (Landroidx/navigation/NavGraphBuilder;Ldev/teogor/ceres/framework/core/app/BaseActions;Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;Ldev/teogor/ceres/navigation/core/ScreenRoute;Ljava/util/List;ILjava/lang/Object;)V
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/OnboardingRoute : dev/teogor/ceres/navigation/core/ScreenRoute {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/OnboardingRoute;
+	public fun getRoute ()Ljava/lang/String;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun areAllPermissionsGranted ()Z
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppName ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getPermissionCategories ()Ljava/util/List;
+	public final fun getPrivacyPolicyLink ()Ljava/lang/String;
+	public final fun getSupportEmail ()Ljava/lang/String;
+	public final fun getTermsOfServiceLink ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/Permission {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Ldev/teogor/ceres/screen/ui/onboarding/Permission;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/screen/ui/onboarding/Permission;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Ldev/teogor/ceres/screen/ui/onboarding/Permission;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getManifestPermission ()Ljava/lang/String;
+	public final fun getPermissionRequired ()Z
+	public final fun getRationaleContent ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isGranted ()Z
+	public final fun setGranted (Z)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/PermissionCategory {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Ldev/teogor/ceres/screen/ui/onboarding/PermissionCategory;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/screen/ui/onboarding/PermissionCategory;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Ldev/teogor/ceres/screen/ui/onboarding/PermissionCategory;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPermissions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/PermissionRoute : dev/teogor/ceres/navigation/core/ScreenRoute {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/PermissionRoute;
+	public fun getRoute ()Ljava/lang/String;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/model/OnboardingScreen : java/lang/Enum {
+	public static final field AD_CHOICES Ldev/teogor/ceres/screen/ui/onboarding/model/OnboardingScreen;
+	public static final field INTRO Ldev/teogor/ceres/screen/ui/onboarding/model/OnboardingScreen;
+	public static final field LEGAL Ldev/teogor/ceres/screen/ui/onboarding/model/OnboardingScreen;
+	public static final field PERMISSION Ldev/teogor/ceres/screen/ui/onboarding/model/OnboardingScreen;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/teogor/ceres/screen/ui/onboarding/model/OnboardingScreen;
+	public static fun values ()[Ldev/teogor/ceres/screen/ui/onboarding/model/OnboardingScreen;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/screens/AdChoicesScreenKt {
+	public static final fun AdChoicesScreen (Landroidx/compose/foundation/layout/BoxScope;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/screens/ComposableSingletons$AdChoicesScreenKt {
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/screens/ComposableSingletons$AdChoicesScreenKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-3 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-3$ui_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/screens/ComposableSingletons$IntroScreenKt {
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/screens/ComposableSingletons$IntroScreenKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$ui_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/screens/ComposableSingletons$LegalScreenKt {
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/screens/ComposableSingletons$LegalScreenKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-10 Lkotlin/jvm/functions/Function3;
+	public static field lambda-11 Lkotlin/jvm/functions/Function3;
+	public static field lambda-12 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-3 Lkotlin/jvm/functions/Function3;
+	public static field lambda-4 Lkotlin/jvm/functions/Function3;
+	public static field lambda-5 Lkotlin/jvm/functions/Function3;
+	public static field lambda-6 Lkotlin/jvm/functions/Function3;
+	public static field lambda-7 Lkotlin/jvm/functions/Function3;
+	public static field lambda-8 Lkotlin/jvm/functions/Function3;
+	public static field lambda-9 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-10$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-11$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-12$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-3$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-4$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-5$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-6$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-7$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-8$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-9$ui_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/screens/ComposableSingletons$PermissionScreenKt {
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/screens/ComposableSingletons$PermissionScreenKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-3 Lkotlin/jvm/functions/Function3;
+	public static field lambda-4 Lkotlin/jvm/functions/Function3;
+	public static field lambda-5 Lkotlin/jvm/functions/Function3;
+	public static field lambda-6 Lkotlin/jvm/functions/Function3;
+	public static field lambda-7 Lkotlin/jvm/functions/Function3;
+	public static field lambda-8 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-3$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-4$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-5$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-6$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-7$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-8$ui_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/screens/IntroScreenKt {
+	public static final fun IntroScreen (Landroidx/compose/foundation/layout/BoxScope;Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/screens/LegalScreenKt {
+	public static final fun LegalScreen (Landroidx/compose/foundation/layout/BoxScope;Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public static final fun divider (Landroidx/compose/foundation/lazy/LazyListScope;Landroidx/compose/ui/Modifier;)V
+	public static synthetic fun divider$default (Landroidx/compose/foundation/lazy/LazyListScope;Landroidx/compose/ui/Modifier;ILjava/lang/Object;)V
+	public static final fun header (Landroidx/compose/foundation/lazy/LazyListScope;Ljava/lang/String;Landroidx/compose/ui/Modifier;)V
+	public static synthetic fun header$default (Landroidx/compose/foundation/lazy/LazyListScope;Ljava/lang/String;Landroidx/compose/ui/Modifier;ILjava/lang/Object;)V
+	public static final fun legalTitle (Landroidx/compose/foundation/lazy/LazyListScope;)V
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/screens/PermissionScreenKt {
+	public static final fun PermissionScreen (Landroidx/compose/foundation/layout/BoxScope;Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public static final fun hasPermissions (Landroid/content/Context;Ljava/lang/String;)Z
+	public static final fun permission (Landroidx/compose/foundation/lazy/LazyListScope;Ldev/teogor/ceres/screen/ui/onboarding/Permission;Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/screens/PrivacyPolicy : dev/teogor/ceres/ui/designsystem/ClickableElement {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/screens/PrivacyPolicy;
+}
+
+public final class dev/teogor/ceres/screen/ui/onboarding/screens/TermsOfService : dev/teogor/ceres/ui/designsystem/ClickableElement {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/screens/TermsOfService;
+}
+
 public final class dev/teogor/ceres/screen/ui/settings/ComposableSingletons$SettingsComponentsKt {
 	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/settings/ComposableSingletons$SettingsComponentsKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;

--- a/screen/ui/build.gradle.kts
+++ b/screen/ui/build.gradle.kts
@@ -41,6 +41,9 @@ dependencies {
   implementation(libs.about.libraries.core)
   // used for toImmutableList
   implementation(libs.kotlinx.collections)
+
+  // TODO move to :core:$module
+  implementation(libs.accompanist.permissions)
 }
 
 ceresLibrary {

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/api/ScreenUiApi.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/api/ScreenUiApi.kt
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package dev.teogor.ceres.screen.ui.onboarding.model
+package dev.teogor.ceres.screen.ui.api
 
-enum class OnboardingScreen {
-  INTRO,
-  LEGAL,
-  PERMISSION,
-  AD_CHOICES,
-}
+@RequiresOptIn(
+  message = "The Onboarding Screen API is currently experimental and may be subject to changes in future releases. Use with caution.",
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class ExperimentalOnboardingScreenApi

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingNavigation.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingNavigation.kt
@@ -1,0 +1,96 @@
+package dev.teogor.ceres.screen.ui.onboarding
+
+import androidx.navigation.NavGraphBuilder
+import dev.teogor.ceres.data.datastore.defaults.ceresPreferences
+import dev.teogor.ceres.framework.core.app.BaseActions
+import dev.teogor.ceres.navigation.core.LocalNavigationParameters
+import dev.teogor.ceres.navigation.core.ScreenRoute
+import dev.teogor.ceres.navigation.core.screenNav
+import dev.teogor.ceres.screen.ui.onboarding.model.OnboardingScreen
+
+private const val navPath = "onboarding_path"
+
+object OnboardingRoute : ScreenRoute {
+  override val route: String = navPath
+}
+
+private const val introNavPath = "intro_path"
+
+object IntroRoute : ScreenRoute {
+  override val route: String = introNavPath
+}
+
+private const val legalNavPath = "legal_path"
+
+object LegalRoute : ScreenRoute {
+  override val route: String = legalNavPath
+}
+
+private const val adChoicesNavPath = "ad_choices_path"
+
+object AdChoicesRoute : ScreenRoute {
+  override val route: String = adChoicesNavPath
+}
+
+private const val permissionNavPath = "permission_path"
+
+object PermissionRoute : ScreenRoute {
+  override val route: String = permissionNavPath
+}
+
+fun NavGraphBuilder.onboardingNavPath(
+  baseActions: BaseActions,
+  onboardingData: OnboardingScreenData,
+  endRoute: ScreenRoute,
+  screens: List<OnboardingScreen> = listOf(
+    OnboardingScreen.INTRO,
+    OnboardingScreen.LEGAL,
+    OnboardingScreen.PERMISSION,
+    OnboardingScreen.AD_CHOICES,
+  ),
+) {
+  screenNav(navPath) {
+    val navigationParameters = LocalNavigationParameters.current
+    navigationParameters.screenRoute = if (screens.isEmpty()) {
+      throw IllegalArgumentException("The 'screens' list must not be empty.")
+    } else {
+      when (screens.first()) {
+        OnboardingScreen.INTRO -> IntroRoute
+        OnboardingScreen.LEGAL -> LegalRoute
+        OnboardingScreen.PERMISSION -> PermissionRoute
+        OnboardingScreen.AD_CHOICES -> AdChoicesRoute
+      }
+    }
+  }
+  screens.forEachIndexed { index, screen ->
+    val isLast = index == screens.size - 1
+    val isFirst = index == 0
+    screenNav(screen.screenRoute().route) {
+      val navigationParameters = LocalNavigationParameters.current
+      OnboardingGraphBeta(
+        baseActions = baseActions,
+        onboardingData = onboardingData,
+        screen = screen,
+        onNext = {
+          if (isLast) {
+            ceresPreferences().onboardingComplete = true
+            navigationParameters.screenRoute = endRoute
+          } else {
+            navigationParameters.screenRoute = screens[index + 1].screenRoute()
+          }
+        },
+      ) {
+        if (!isFirst) {
+          navigationParameters.screenRoute = screens[index - 1].screenRoute()
+        }
+      }
+    }
+  }
+}
+
+private fun OnboardingScreen.screenRoute() = when (this) {
+  OnboardingScreen.INTRO -> IntroRoute
+  OnboardingScreen.LEGAL -> LegalRoute
+  OnboardingScreen.PERMISSION -> PermissionRoute
+  OnboardingScreen.AD_CHOICES -> AdChoicesRoute
+}

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingNavigation.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingNavigation.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.teogor.ceres.screen.ui.onboarding
 
 import androidx.navigation.NavGraphBuilder
@@ -6,10 +22,12 @@ import dev.teogor.ceres.framework.core.app.BaseActions
 import dev.teogor.ceres.navigation.core.LocalNavigationParameters
 import dev.teogor.ceres.navigation.core.ScreenRoute
 import dev.teogor.ceres.navigation.core.screenNav
+import dev.teogor.ceres.screen.ui.api.ExperimentalOnboardingScreenApi
 import dev.teogor.ceres.screen.ui.onboarding.model.OnboardingScreen
 
 private const val navPath = "onboarding_path"
 
+@ExperimentalOnboardingScreenApi
 object OnboardingRoute : ScreenRoute {
   override val route: String = navPath
 }
@@ -38,6 +56,7 @@ object PermissionRoute : ScreenRoute {
   override val route: String = permissionNavPath
 }
 
+@ExperimentalOnboardingScreenApi
 fun NavGraphBuilder.onboardingNavPath(
   baseActions: BaseActions,
   onboardingData: OnboardingScreenData,

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingRoute.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingRoute.kt
@@ -1,0 +1,87 @@
+package dev.teogor.ceres.screen.ui.onboarding
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import dev.teogor.ceres.framework.core.app.BaseActions
+import dev.teogor.ceres.framework.core.app.setScreenInfo
+import dev.teogor.ceres.framework.core.screen.floatingButton
+import dev.teogor.ceres.framework.core.screen.isStatusBarVisible
+import dev.teogor.ceres.framework.core.screen.isVisible
+import dev.teogor.ceres.framework.core.screen.showNavBar
+import dev.teogor.ceres.framework.core.screen.toolbarTokens
+import dev.teogor.ceres.screen.ui.onboarding.model.OnboardingScreen
+import dev.teogor.ceres.screen.ui.onboarding.screens.AdChoicesScreen
+import dev.teogor.ceres.screen.ui.onboarding.screens.IntroScreen
+import dev.teogor.ceres.screen.ui.onboarding.screens.LegalScreen
+import dev.teogor.ceres.screen.ui.onboarding.screens.PermissionScreen
+
+@Composable
+internal fun OnboardingGraphBeta(
+  baseActions: BaseActions,
+  onboardingData: OnboardingScreenData,
+  screen: OnboardingScreen,
+  onNext: () -> Unit,
+  onPrevious: () -> Unit,
+) {
+  baseActions.setScreenInfo {
+    showNavBar {
+      false
+    }
+
+    isStatusBarVisible {
+      true
+    }
+
+    toolbarTokens {
+      isVisible {
+        false
+      }
+    }
+
+    floatingButton {
+      isVisible {
+        false
+      }
+    }
+  }
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize(),
+  ) {
+    when (screen) {
+      OnboardingScreen.INTRO -> {
+        IntroScreen(
+          data = onboardingData,
+          onNext = onNext,
+          onBack = onPrevious,
+        )
+      }
+
+      OnboardingScreen.LEGAL -> {
+        LegalScreen(
+          data = onboardingData,
+          onNext = onNext,
+          onBack = onPrevious,
+        )
+      }
+
+      OnboardingScreen.PERMISSION -> {
+        PermissionScreen(
+          data = onboardingData,
+          onNext = onNext,
+          onBack = onPrevious,
+        )
+      }
+
+      OnboardingScreen.AD_CHOICES -> {
+        AdChoicesScreen(
+          onBack = onPrevious,
+          onNext = onNext,
+        )
+      }
+    }
+  }
+}

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingRoute.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingRoute.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.teogor.ceres.screen.ui.onboarding
 
 import androidx.compose.foundation.layout.Box
@@ -11,12 +27,14 @@ import dev.teogor.ceres.framework.core.screen.isStatusBarVisible
 import dev.teogor.ceres.framework.core.screen.isVisible
 import dev.teogor.ceres.framework.core.screen.showNavBar
 import dev.teogor.ceres.framework.core.screen.toolbarTokens
+import dev.teogor.ceres.screen.ui.api.ExperimentalOnboardingScreenApi
 import dev.teogor.ceres.screen.ui.onboarding.model.OnboardingScreen
 import dev.teogor.ceres.screen.ui.onboarding.screens.AdChoicesScreen
 import dev.teogor.ceres.screen.ui.onboarding.screens.IntroScreen
 import dev.teogor.ceres.screen.ui.onboarding.screens.LegalScreen
 import dev.teogor.ceres.screen.ui.onboarding.screens.PermissionScreen
 
+@OptIn(ExperimentalOnboardingScreenApi::class)
 @Composable
 internal fun OnboardingGraphBeta(
   baseActions: BaseActions,

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData.kt
@@ -1,5 +1,24 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.teogor.ceres.screen.ui.onboarding
 
+import dev.teogor.ceres.screen.ui.api.ExperimentalOnboardingScreenApi
+
+@ExperimentalOnboardingScreenApi
 data class OnboardingScreenData(
   val appName: String = "%%APP_NAME%%",
   val description: String = "%%DESCRIPTION%%",
@@ -19,6 +38,7 @@ data class OnboardingScreenData(
   }
 }
 
+@ExperimentalOnboardingScreenApi
 data class Permission(
   val title: String = "%%TITLE%%",
   val description: String = "%%DESCRIPTION%%",
@@ -29,6 +49,7 @@ data class Permission(
   var isGranted: Boolean = false
 }
 
+@ExperimentalOnboardingScreenApi
 data class PermissionCategory(
   val name: String = "%%NAME%%",
   val permissions: List<Permission> = listOf(Permission()),

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData.kt
@@ -1,0 +1,35 @@
+package dev.teogor.ceres.screen.ui.onboarding
+
+data class OnboardingScreenData(
+  val appName: String = "%%APP_NAME%%",
+  val description: String = "%%DESCRIPTION%%",
+  val supportEmail: String = "%%SUPPORT_EMAIL%%",
+  val privacyPolicyLink: String = "%%PRIVACY_POLICY_LINK%%",
+  val termsOfServiceLink: String = "%%TERMS_OF_SERVICE_LINK%%",
+  val permissionCategories: List<PermissionCategory> = listOf(PermissionCategory()),
+) {
+  fun areAllPermissionsGranted(): Boolean {
+    return permissionCategories.all { category ->
+      category.permissions
+        .filter { it.permissionRequired } // Filter only required permissions
+        .all { permission ->
+          permission.isGranted
+        }
+    }
+  }
+}
+
+data class Permission(
+  val title: String = "%%TITLE%%",
+  val description: String = "%%DESCRIPTION%%",
+  val manifestPermission: String = "%%MANIFEST_PERMISSION%%",
+  val permissionRequired: Boolean = false,
+  val rationaleContent: String? = null,
+) {
+  var isGranted: Boolean = false
+}
+
+data class PermissionCategory(
+  val name: String = "%%NAME%%",
+  val permissions: List<Permission> = listOf(Permission()),
+)

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/model/OnboardingScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/model/OnboardingScreen.kt
@@ -1,0 +1,8 @@
+package dev.teogor.ceres.screen.ui.onboarding.model
+
+enum class OnboardingScreen {
+    INTRO,
+    LEGAL,
+    PERMISSION,
+    AD_CHOICES
+}

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/AdChoicesScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/AdChoicesScreen.kt
@@ -1,0 +1,102 @@
+package dev.teogor.ceres.screen.ui.onboarding.screens
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.teogor.ceres.screen.core.layout.LayoutWithBottomHeader
+import dev.teogor.ceres.ui.designsystem.Button
+import dev.teogor.ceres.ui.designsystem.HorizontalDivider
+import dev.teogor.ceres.ui.designsystem.OutlinedButton
+import dev.teogor.ceres.ui.designsystem.Text
+import dev.teogor.ceres.ui.theme.MaterialTheme
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun BoxScope.AdChoicesScreen(
+  onBack: () -> Unit,
+  onNext: () -> Unit,
+) {
+  // val networkConnectivity = LocalNetworkConnectivity.current
+  // val state by remember { ConsentManager.state }
+  // val canRequestAds: Boolean = remember(state) {
+  //   when (val consentResult = state) {
+  //     is ConsentResult.ConsentFormAcquired -> consentResult.canRequestAds
+  //     is ConsentResult.ConsentFormDismissed -> consentResult.canRequestAds
+  //     else -> false
+  //   }
+  // }
+  // // todo state when consent is shown
+  // LaunchedEffect(state, canRequestAds, networkConnectivity.isOffline) {
+  //   if (canRequestAds || networkConnectivity.isOffline) {
+  //     onNext()
+  //   } else {
+  //     ConsentManager.loadAndShowConsentFormIfRequired()
+  //   }
+  // }
+
+  LayoutWithBottomHeader(
+    hasScrollbar = false,
+    bottomContent = {
+      Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        if(!true) {
+          LinearProgressIndicator(
+            modifier = Modifier.fillMaxWidth(),
+            color = MaterialTheme.colorScheme.primary,
+          )
+        } else {
+          HorizontalDivider(
+            modifier = Modifier.padding(bottom = 10.dp),
+            thickness = 1.dp,
+          )
+        }
+
+        Spacer(modifier = Modifier.height(15.dp))
+
+        Row(
+          modifier = Modifier.padding(horizontal = 20.dp),
+        ) {
+          OutlinedButton(
+            onClick = onBack,
+          ) {
+            Text(
+              text = "Back",
+              modifier = Modifier
+                .padding(end = 10.dp, start = 10.dp),
+            )
+          }
+          Spacer(modifier = Modifier.weight(1f))
+          Button(
+            onClick = onNext,
+          ) {
+            Text(
+              text = "Next",
+              modifier = Modifier
+                .padding(end = 10.dp, start = 10.dp),
+            )
+          }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+      }
+    },
+  ) {
+    stickyHeader {
+      HorizontalDivider(
+        thickness = 1.dp,
+      )
+    }
+  }
+}

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/AdChoicesScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/AdChoicesScreen.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.teogor.ceres.screen.ui.onboarding.screens
 
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -10,9 +26,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import dev.teogor.ceres.monetisation.ads.ExperimentalAdsControlApi
+import dev.teogor.ceres.monetisation.ads.HandleAdsConsent
+import dev.teogor.ceres.monetisation.ads.LocalAdsControl
+import dev.teogor.ceres.monetisation.ads.consentIsShowing
 import dev.teogor.ceres.screen.core.layout.LayoutWithBottomHeader
 import dev.teogor.ceres.ui.designsystem.Button
 import dev.teogor.ceres.ui.designsystem.HorizontalDivider
@@ -20,29 +42,18 @@ import dev.teogor.ceres.ui.designsystem.OutlinedButton
 import dev.teogor.ceres.ui.designsystem.Text
 import dev.teogor.ceres.ui.theme.MaterialTheme
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalAdsControlApi::class)
 @Composable
 fun BoxScope.AdChoicesScreen(
   onBack: () -> Unit,
   onNext: () -> Unit,
 ) {
-  // val networkConnectivity = LocalNetworkConnectivity.current
-  // val state by remember { ConsentManager.state }
-  // val canRequestAds: Boolean = remember(state) {
-  //   when (val consentResult = state) {
-  //     is ConsentResult.ConsentFormAcquired -> consentResult.canRequestAds
-  //     is ConsentResult.ConsentFormDismissed -> consentResult.canRequestAds
-  //     else -> false
-  //   }
-  // }
-  // // todo state when consent is shown
-  // LaunchedEffect(state, canRequestAds, networkConnectivity.isOffline) {
-  //   if (canRequestAds || networkConnectivity.isOffline) {
-  //     onNext()
-  //   } else {
-  //     ConsentManager.loadAndShowConsentFormIfRequired()
-  //   }
-  // }
+  val adsControl = LocalAdsControl.current
+  val canRequestAds by remember { adsControl.canRequestAds }
+  HandleAdsConsent(
+    onAdsConsentGranted = onNext,
+    onAdsConsentRejected = onNext,
+  )
 
   LayoutWithBottomHeader(
     hasScrollbar = false,
@@ -51,7 +62,7 @@ fun BoxScope.AdChoicesScreen(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
       ) {
-        if(!true) {
+        if (!adsControl.consentIsShowing && !canRequestAds) {
           LinearProgressIndicator(
             modifier = Modifier.fillMaxWidth(),
             color = MaterialTheme.colorScheme.primary,
@@ -80,6 +91,7 @@ fun BoxScope.AdChoicesScreen(
           Spacer(modifier = Modifier.weight(1f))
           Button(
             onClick = onNext,
+            enabled = canRequestAds,
           ) {
             Text(
               text = "Next",

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/IntroScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/IntroScreen.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.teogor.ceres.screen.ui.onboarding.screens
 
 import androidx.compose.animation.AnimatedVisibility
@@ -18,11 +34,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.teogor.ceres.screen.ui.api.ExperimentalOnboardingScreenApi
 import dev.teogor.ceres.screen.ui.onboarding.OnboardingScreenData
 import dev.teogor.ceres.ui.designsystem.Button
 import dev.teogor.ceres.ui.designsystem.Text
 import dev.teogor.ceres.ui.theme.MaterialTheme
 
+@OptIn(ExperimentalOnboardingScreenApi::class)
 @Composable
 fun BoxScope.IntroScreen(
   data: OnboardingScreenData,
@@ -100,4 +118,3 @@ fun BoxScope.IntroScreen(
     }
   }
 }
-

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/IntroScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/IntroScreen.kt
@@ -1,0 +1,103 @@
+package dev.teogor.ceres.screen.ui.onboarding.screens
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.teogor.ceres.screen.ui.onboarding.OnboardingScreenData
+import dev.teogor.ceres.ui.designsystem.Button
+import dev.teogor.ceres.ui.designsystem.Text
+import dev.teogor.ceres.ui.theme.MaterialTheme
+
+@Composable
+fun BoxScope.IntroScreen(
+  data: OnboardingScreenData,
+  onBack: () -> Unit,
+  onNext: () -> Unit,
+) {
+  Column(
+    modifier = Modifier
+      .align(Alignment.TopCenter)
+      .fillMaxWidth()
+      .padding(horizontal = 20.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(
+      text = "Welcome to",
+      color = MaterialTheme.colorScheme.onBackground,
+      textAlign = TextAlign.Center,
+      fontSize = 30.sp,
+      fontWeight = FontWeight.Bold,
+      modifier = Modifier.padding(top = 50.dp),
+    )
+
+    Text(
+      text = data.appName,
+      color = MaterialTheme.colorScheme.primary,
+      textAlign = TextAlign.Center,
+      fontSize = 40.sp,
+      fontWeight = FontWeight.ExtraBold,
+      modifier = Modifier.padding(top = 0.dp),
+    )
+  }
+
+  AnimatedVisibility(
+    modifier = Modifier
+      .align(Alignment.BottomCenter),
+    visible = true,
+    enter = fadeIn() + slideInVertically(
+      initialOffsetY = { it },
+      animationSpec = tween(durationMillis = 300),
+    ),
+    exit = slideOutVertically(
+      targetOffsetY = { it },
+      animationSpec = tween(durationMillis = 300),
+    ) + fadeOut(),
+  ) {
+    Column(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 20.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      Text(
+        text = data.description,
+        color = MaterialTheme.colorScheme.secondary,
+        fontSize = 16.sp,
+        lineHeight = 18.sp,
+        fontWeight = FontWeight.Normal,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+      )
+
+      Button(
+        onClick = onNext,
+        contentPadding = PaddingValues(
+          horizontal = 24.dp,
+          vertical = 16.dp,
+        ),
+        modifier = Modifier.padding(bottom = 30.dp),
+      ) {
+        Text(
+          text = "Get started",
+          modifier = Modifier.padding(end = 10.dp, start = 10.dp),
+        )
+      }
+    }
+  }
+}
+

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/LegalScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/LegalScreen.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.teogor.ceres.screen.ui.onboarding.screens
 
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -33,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.teogor.ceres.screen.core.layout.LayoutWithBottomHeader
 import dev.teogor.ceres.screen.core.scope.ScreenListScope
+import dev.teogor.ceres.screen.ui.api.ExperimentalOnboardingScreenApi
 import dev.teogor.ceres.screen.ui.onboarding.OnboardingScreenData
 import dev.teogor.ceres.ui.designsystem.Button
 import dev.teogor.ceres.ui.designsystem.CheckboxWithText
@@ -45,7 +62,7 @@ import dev.teogor.ceres.ui.foundation.clickable
 import dev.teogor.ceres.ui.theme.MaterialTheme
 import dev.teogor.ceres.ui.theme.core.SurfaceOverlay
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalOnboardingScreenApi::class)
 @Composable
 fun BoxScope.LegalScreen(
   data: OnboardingScreenData,

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/LegalScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/LegalScreen.kt
@@ -1,0 +1,369 @@
+package dev.teogor.ceres.screen.ui.onboarding.screens
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.teogor.ceres.screen.core.layout.LayoutWithBottomHeader
+import dev.teogor.ceres.screen.core.scope.ScreenListScope
+import dev.teogor.ceres.screen.ui.onboarding.OnboardingScreenData
+import dev.teogor.ceres.ui.designsystem.Button
+import dev.teogor.ceres.ui.designsystem.CheckboxWithText
+import dev.teogor.ceres.ui.designsystem.ClickableElement
+import dev.teogor.ceres.ui.designsystem.HorizontalDivider
+import dev.teogor.ceres.ui.designsystem.OutlinedButton
+import dev.teogor.ceres.ui.designsystem.ParsableText
+import dev.teogor.ceres.ui.designsystem.Text
+import dev.teogor.ceres.ui.foundation.clickable
+import dev.teogor.ceres.ui.theme.MaterialTheme
+import dev.teogor.ceres.ui.theme.core.SurfaceOverlay
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun BoxScope.LegalScreen(
+  data: OnboardingScreenData,
+  onBack: () -> Unit,
+  onNext: () -> Unit,
+) = LayoutWithBottomHeader(
+  hasScrollbar = false,
+  bottomContent = {
+    Column(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      HorizontalDivider(
+        modifier = Modifier.padding(bottom = 10.dp),
+        thickness = 1.dp,
+      )
+
+      var agreedPp by rememberSaveable { mutableStateOf(false) }
+      var agreedTos by rememberSaveable { mutableStateOf(false) }
+
+      CheckboxWithText(
+        text = "I agree with Privacy Policy",
+        isChecked = agreedPp,
+        onCheckedChange = { agreedPp = it },
+        modifier = Modifier
+          .padding(horizontal = 10.dp),
+      )
+      CheckboxWithText(
+        text = "I agree with Terms of Service",
+        isChecked = agreedTos,
+        onCheckedChange = { agreedTos = it },
+        modifier = Modifier
+          .padding(horizontal = 10.dp),
+      )
+
+      Spacer(modifier = Modifier.height(4.dp))
+
+      Row(
+        modifier = Modifier.padding(horizontal = 20.dp),
+      ) {
+        OutlinedButton(
+          onClick = onBack,
+        ) {
+          Text(
+            text = "Back",
+            modifier = Modifier
+              .padding(end = 10.dp, start = 10.dp),
+          )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Button(
+          onClick = onNext,
+          enabled = agreedTos && agreedPp,
+        ) {
+          Text(
+            text = "Accept",
+            modifier = Modifier
+              .padding(end = 10.dp, start = 10.dp),
+          )
+        }
+      }
+
+      Spacer(modifier = Modifier.height(8.dp))
+    }
+  },
+) {
+  legalTitle()
+
+  item {
+    Spacer(modifier = Modifier.height(6.dp))
+  }
+  stickyHeader {
+    HorizontalDivider(
+      thickness = 1.dp,
+    )
+  }
+  item {
+    Spacer(modifier = Modifier.height(10.dp))
+  }
+
+  header("Data Collection")
+
+  item {
+    Text(
+      text = "Our commitment to privacy includes the responsible collection and handling of your personal data. Here, we detail the various types of information we gather, how we utilize it, and the rights and choices available to you.",
+      color = MaterialTheme.colorScheme.onBackground,
+      fontSize = 12.sp,
+      lineHeight = 14.sp,
+      textAlign = TextAlign.Start,
+      modifier = Modifier
+        .padding(horizontal = 14.dp)
+        .padding(top = 10.dp, bottom = 4.dp),
+    )
+  }
+
+  item {
+    Spacer(modifier = Modifier.height(10.dp))
+  }
+
+  header("Data Collection Details")
+
+  item {
+    StyledInfoSection(
+      title = "Types of Personal Data We Collect",
+      items = listOf(
+        "Information you provide when you register for an account or use our services, such as your name.",
+        "Information we collect automatically, such as your IP address, device type.",
+        "Information we collect from third-party sources, such as social media platforms or advertising partners.",
+      ),
+    )
+  }
+
+  header("Data Utilization Overview")
+
+  item {
+    StyledInfoSection(
+      title = "How We Use Your Personal Data",
+      items = listOf(
+        "To provide and improve our services, personalize your experience, and communicate with you.",
+        "To analyze and improve our products and services, as well as to develop new features and offerings.",
+        "To show you targeted advertising and measure the effectiveness of our advertising campaigns.",
+        "To comply with legal and regulatory requirements.",
+      ),
+    )
+  }
+
+  header("Your Privacy Rights")
+
+  item {
+    StyledInfoSection(
+      title = "Your Rights and Choices",
+      items = listOf(
+        "You have the right to access, correct, or delete your personal data.",
+        "You can opt-out of receiving marketing communications from us at any time.",
+        "You can choose to disable cookies in your browser menu.",
+        "We honor 'Do Not Track' signals and offer opt-out mechanisms for certain types of data processing.",
+      ),
+    )
+  }
+
+  header("Data Security Measures")
+
+  item {
+    StyledInfoSection(
+      title = "How We Protect Your Personal Data",
+      items = listOf(
+        "We use industry-standard security measures to protect your personal data.",
+        "We limit access to your personal data to authorized personnel only.",
+        "We regularly review and update our security practices to ensure they meet the highest standards.",
+      ),
+    )
+  }
+
+  header("Contact and Agreement")
+
+  item {
+    StyledInfoSection(
+      title = "Contact Us",
+      items = listOf(
+        "If you have any questions or concerns about our privacy practices, please contact us at ${data.supportEmail}.",
+      ),
+      highlights = listOf(data.supportEmail),
+    )
+
+    val uriHandler = LocalUriHandler.current
+    ParsableText(
+      text = "By using this app, you agree to our Privacy Policy and Terms of Service.",
+      elements = listOf(
+        PrivacyPolicy,
+        TermsOfService,
+      ),
+      onElementClicked = { element ->
+        when (element) {
+          is PrivacyPolicy -> {
+            val url = data.termsOfServiceLink
+            uriHandler.openUri(url)
+          }
+
+          is TermsOfService -> {
+            val url = data.privacyPolicyLink
+            uriHandler.openUri(url)
+          }
+        }
+      },
+      modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+    )
+  }
+}
+
+object PrivacyPolicy : ClickableElement("Privacy Policy")
+object TermsOfService : ClickableElement("Terms of Service")
+
+fun ScreenListScope.header(
+  title: String,
+  modifier: Modifier = Modifier,
+) = item {
+  Text(
+    modifier = modifier
+      .padding(
+        top = 6.dp,
+        bottom = 0.dp,
+      )
+      .padding(horizontal = 30.dp),
+    text = title,
+    fontSize = 13.sp,
+    fontWeight = FontWeight.Medium,
+    lineHeight = 13.sp,
+    color = MaterialTheme.colorScheme.secondary,
+  )
+}
+
+fun ScreenListScope.legalTitle() = item {
+  val text = buildAnnotatedString {
+    append("Your ")
+    withStyle(
+      style = SpanStyle(
+        color = MaterialTheme.colorScheme.primary,
+        fontWeight = FontWeight.Medium,
+      ),
+    ) {
+      append("Privacy")
+    }
+    append("\nMatters to Us")
+  }
+
+  Text(
+    text = text,
+    color = MaterialTheme.colorScheme.onBackground,
+    textAlign = TextAlign.Center,
+    fontSize = 22.sp,
+    lineHeight = 24.sp,
+    fontWeight = FontWeight.Normal,
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(top = 30.dp, bottom = 10.dp),
+  )
+}
+
+fun ScreenListScope.divider(
+  modifier: Modifier = Modifier,
+) = item {
+  HorizontalDivider(
+    modifier = modifier,
+    thickness = 1.dp,
+  )
+}
+
+@Composable
+private fun StyledInfoSection(
+  title: String,
+  items: List<String>,
+  highlights: List<String> = emptyList(),
+  titleColor: Color = MaterialTheme.colorScheme.onSurface,
+) {
+  val colorScheme = MaterialTheme.colorScheme
+  val surfaceOverlay = SurfaceOverlay(
+    themeOverlayColor = colorScheme.surface.toArgb(),
+    themeSurfaceColor = colorScheme.primary.toArgb(),
+  )
+  val background = surfaceOverlay.forAlpha(overlayAlpha = 0.12f)
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(vertical = 8.dp, horizontal = 20.dp)
+      .clip(shape = RoundedCornerShape(10.dp))
+      .background(background)
+      .clickable(
+        onClick = {
+        },
+        indication = rememberRipple(
+          color = colorScheme.primary,
+        ),
+        interactionSource = remember { MutableInteractionSource() },
+      )
+      .padding(4.dp),
+  ) {
+    Column(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 10.dp)
+        .align(Alignment.CenterVertically),
+    ) {
+      Text(
+        text = title,
+        color = titleColor,
+        fontSize = 14.sp,
+        modifier = Modifier.padding(vertical = 4.dp),
+      )
+      items.forEach { item ->
+        val annotatedString = buildAnnotatedString {
+          val parts = item.split(*highlights.map { it }.toTypedArray())
+          var i = 0
+          parts.forEachIndexed { index, part ->
+            append(part)
+            i += part.length
+            if (index != parts.lastIndex) {
+              val element = highlights[index]
+              pushStringAnnotation(tag = element, annotation = "")
+              withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.tertiary)) {
+                append(element)
+              }
+              pop()
+              i += element.length
+            }
+          }
+        }
+
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          modifier = Modifier.padding(vertical = 6.dp),
+        ) {
+          Text(
+            text = annotatedString,
+            color = MaterialTheme.colorScheme.onBackground,
+            style = MaterialTheme.typography.bodySmall,
+          )
+        }
+      }
+    }
+  }
+}

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/PermissionScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/PermissionScreen.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @file:OptIn(ExperimentalPermissionsApi::class)
 
 package dev.teogor.ceres.screen.ui.onboarding.screens
@@ -39,6 +55,7 @@ import com.google.accompanist.permissions.shouldShowRationale
 import dev.teogor.ceres.screen.builder.compose.SimpleView
 import dev.teogor.ceres.screen.core.layout.LayoutWithBottomHeader
 import dev.teogor.ceres.screen.core.scope.ScreenListScope
+import dev.teogor.ceres.screen.ui.api.ExperimentalOnboardingScreenApi
 import dev.teogor.ceres.screen.ui.onboarding.OnboardingScreenData
 import dev.teogor.ceres.screen.ui.onboarding.Permission
 import dev.teogor.ceres.ui.designsystem.Button
@@ -58,7 +75,7 @@ fun Context.hasPermissions(
   ) == PackageManager.PERMISSION_GRANTED
 }
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalOnboardingScreenApi::class)
 @Composable
 fun BoxScope.PermissionScreen(
   data: OnboardingScreenData,
@@ -158,7 +175,7 @@ fun BoxScope.PermissionScreen(
   }
 }
 
-@OptIn(ExperimentalPermissionsApi::class)
+@OptIn(ExperimentalPermissionsApi::class, ExperimentalOnboardingScreenApi::class)
 fun ScreenListScope.permission(
   permission: Permission,
   onGranted: () -> Unit,

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/PermissionScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/PermissionScreen.kt
@@ -1,0 +1,268 @@
+@file:OptIn(ExperimentalPermissionsApi::class)
+
+package dev.teogor.ceres.screen.ui.onboarding.screens
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Security
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
+import com.google.accompanist.permissions.shouldShowRationale
+import dev.teogor.ceres.screen.builder.compose.SimpleView
+import dev.teogor.ceres.screen.core.layout.LayoutWithBottomHeader
+import dev.teogor.ceres.screen.core.scope.ScreenListScope
+import dev.teogor.ceres.screen.ui.onboarding.OnboardingScreenData
+import dev.teogor.ceres.screen.ui.onboarding.Permission
+import dev.teogor.ceres.ui.designsystem.Button
+import dev.teogor.ceres.ui.designsystem.HorizontalDivider
+import dev.teogor.ceres.ui.designsystem.OutlinedButton
+import dev.teogor.ceres.ui.designsystem.Surface
+import dev.teogor.ceres.ui.designsystem.Text
+import dev.teogor.ceres.ui.theme.MaterialTheme
+import dev.teogor.ceres.ui.theme.contentColorFor
+
+fun Context.hasPermissions(
+  permission: String,
+): Boolean {
+  return ContextCompat.checkSelfPermission(
+    this,
+    permission,
+  ) == PackageManager.PERMISSION_GRANTED
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun BoxScope.PermissionScreen(
+  data: OnboardingScreenData,
+  onBack: () -> Unit,
+  onNext: () -> Unit,
+) {
+  val context = LocalContext.current
+  var allPermissionsGranted by remember {
+    mutableStateOf(data.areAllPermissionsGranted())
+  }
+  LaunchedEffect(Unit) {
+    data.permissionCategories.forEach { permissionCategory ->
+      permissionCategory.permissions.forEach { permission ->
+        permission.isGranted = context.hasPermissions(permission.manifestPermission)
+      }
+    }
+    allPermissionsGranted = data.areAllPermissionsGranted()
+  }
+
+  LayoutWithBottomHeader(
+    hasScrollbar = false,
+    bottomContent = {
+      Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        HorizontalDivider(
+          modifier = Modifier.padding(bottom = 10.dp),
+          thickness = 1.dp,
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Row(
+          modifier = Modifier.padding(horizontal = 20.dp),
+        ) {
+          OutlinedButton(
+            onClick = onBack,
+          ) {
+            Text(
+              text = "Back",
+              modifier = Modifier
+                .padding(end = 10.dp, start = 10.dp),
+            )
+          }
+          Spacer(modifier = Modifier.weight(1f))
+          Button(
+            onClick = onNext,
+            enabled = allPermissionsGranted,
+          ) {
+            Text(
+              text = "Next",
+              modifier = Modifier
+                .padding(end = 10.dp, start = 10.dp),
+            )
+          }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+      }
+    },
+  ) {
+    title()
+
+    item {
+      Spacer(modifier = Modifier.height(6.dp))
+    }
+    stickyHeader {
+      HorizontalDivider(
+        thickness = 1.dp,
+      )
+    }
+    item {
+      Spacer(modifier = Modifier.height(10.dp))
+    }
+
+    data.permissionCategories.forEach { permissionCategory ->
+      item {
+        Spacer(modifier = Modifier.height(10.dp))
+      }
+
+      header(permissionCategory.name)
+
+      permissionCategory.permissions.forEach { permission ->
+        permission(
+          permission = permission,
+          onGranted = {
+            allPermissionsGranted = data.areAllPermissionsGranted()
+          },
+        )
+      }
+    }
+
+    item {
+      Spacer(modifier = Modifier.height(20.dp))
+    }
+  }
+}
+
+@OptIn(ExperimentalPermissionsApi::class)
+fun ScreenListScope.permission(
+  permission: Permission,
+  onGranted: () -> Unit,
+) = item {
+  val permissionState = rememberPermissionState(
+    permission.manifestPermission,
+  )
+  LaunchedEffect(permissionState.status.isGranted) {
+    permission.isGranted = permissionState.status.isGranted
+    onGranted()
+  }
+  SimpleView(
+    title = permission.title,
+    subtitle = permission.description,
+    clickable = {
+      if (!permissionState.status.isGranted) {
+        permissionState.launchPermissionRequest()
+      }
+    },
+    icon = Icons.Filled.Security,
+  ) {
+    val backgroundColor = if (permissionState.status.isGranted) {
+      MaterialTheme.colorScheme.success
+    } else if (permissionState.status.shouldShowRationale) {
+      MaterialTheme.colorScheme.error
+    } else {
+      MaterialTheme.colorScheme.warning
+    }
+    Surface(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(
+          horizontal = 40.dp,
+        )
+        .padding(bottom = 4.dp),
+      afterModifier = Modifier
+        .padding(
+          horizontal = 10.dp,
+          vertical = 6.dp,
+        ),
+      color = backgroundColor,
+      shape = RoundedCornerShape(16.dp),
+      tonalElevation = 10.dp,
+    ) {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        if (permissionState.status.isGranted) {
+          Text(
+            text = "Permission Granted",
+            fontSize = 12.sp,
+            lineHeight = 14.sp,
+            color = contentColorFor(backgroundColor),
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+          )
+        } else {
+          val textToShow = if (permissionState.status.shouldShowRationale) {
+            // If the user has denied the permission but the rationale can be shown,
+            // then gently explain why the app requires this permission
+            "The camera is important for this app. Please grant the permission."
+          } else {
+            // If it's the first time the user lands on this feature, or the user
+            // doesn't want to be asked again for this permission, explain that the
+            // permission is required
+            "Not Granted"
+          }
+          Text(
+            text = textToShow,
+            fontSize = 12.sp,
+            lineHeight = 14.sp,
+            color = contentColorFor(backgroundColor),
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+      }
+    }
+  }
+}
+
+private fun ScreenListScope.title() = item {
+  val text = buildAnnotatedString {
+    append("Grant ")
+    withStyle(
+      style = SpanStyle(
+        color = MaterialTheme.colorScheme.primary,
+        fontWeight = FontWeight.Medium,
+      ),
+    ) {
+      append("Permissions")
+    }
+  }
+
+  Text(
+    text = text,
+    color = MaterialTheme.colorScheme.onBackground,
+    textAlign = TextAlign.Center,
+    fontSize = 22.sp,
+    lineHeight = 24.sp,
+    fontWeight = FontWeight.Normal,
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(top = 30.dp, bottom = 10.dp),
+  )
+}


### PR DESCRIPTION
In this pull request, we introduce an Onboarding Screen to enhance the user experience and provide important information about the app's functionality. The Onboarding Screen is a crucial step for new users and helps them understand the app's features and permissions.

**Changes Made:**

1. Added a new package `dev.teogor.ceres.screen.ui.onboarding` to contain the Onboarding Screen components.
2. Introduced `OnboardingRoute` as a new screen route for the Onboarding Screen.
3. Created the `OnboardingScreenData` class to store data related to the Onboarding Screen, including app name, description, permissions, privacy policy link, terms of service link, and permission categories.
4. Added `Permission`, `PermissionCategory`, `PrivacyPolicy`, and `TermsOfService` classes to handle permissions and legal information.
5. Created enum `OnboardingScreen` to represent different Onboarding Screen sections.
6. Implemented individual screens for the Onboarding Screen, including `IntroScreen`, `LegalScreen`, `AdChoicesScreen`, and `PermissionScreen`.
7. Added navigation paths for the Onboarding Screen using `NavGraphBuilder`.
8. Modified the `NavHost` to determine the start destination based on whether the Onboarding Screen is complete and if consent to show ads is granted.
9. Updated the navigation logic to include the Onboarding Screen as part of the user onboarding process.

closes #125 