### PR TITLE
Add NavigationItem class for Representing Navigation Items

### DIFF
--- a/app/src/main/kotlin/dev/teogor/ceres/MainActivity.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/MainActivity.kt
@@ -23,7 +23,7 @@ import dev.teogor.ceres.framework.core.model.MenuConfig
 import dev.teogor.ceres.framework.core.model.NavGraphOptions
 import dev.teogor.ceres.menu.applyMenuConfig
 import dev.teogor.ceres.navigation.ApplyNavHost
-import dev.teogor.ceres.navigation.core.menu.TopLevelDestination
+import dev.teogor.ceres.navigation.core.models.NavigationItem
 
 /**
  * The main activity of the Ceres application.
@@ -36,10 +36,10 @@ class MainActivity : Activity() {
   /**
    * Gets the list of top-level destinations based on the current screen.
    *
-   * @return A list of [TopLevelDestination] for the current screen.
+   * @return A list of [NavigationItem] for the current screen.
    */
-  override val topLevelDestinations: List<TopLevelDestination>
-    get() = super.topLevelDestinations
+  override val navigationItems: List<NavigationItem>
+    get() = super.navigationItems
 
   /**
    * Builds and applies the navigation graph for the Ceres application using [NavGraphOptions].

--- a/framework/core/api/core.api
+++ b/framework/core/api/core.api
@@ -10,8 +10,8 @@ public class dev/teogor/ceres/framework/core/Activity : androidx/activity/Compon
 	public final fun getAnalyticsHelper ()Ldev/teogor/ceres/firebase/analytics/AnalyticsHelper;
 	public final fun getCrashlyticsHelper ()Ldev/teogor/ceres/firebase/crashlytics/CrashlyticsHelper;
 	public final fun getLazyStats ()Ldagger/Lazy;
+	public fun getNavigationItems ()Ljava/util/List;
 	public final fun getNetworkMonitor ()Ldev/teogor/ceres/core/network/NetworkMonitor;
-	public fun getTopLevelDestinations ()Ljava/util/List;
 	public fun handleUriVariants (Landroid/net/Uri;)Ldev/teogor/ceres/navigation/core/ScreenRoute;
 	public final fun navigateTo (Ldev/teogor/ceres/navigation/core/ScreenRoute;)V
 	protected fun onCreate (Landroid/os/Bundle;)V
@@ -84,18 +84,18 @@ public final class dev/teogor/ceres/framework/core/app/CeresAppState {
 	public final fun getCurrentDestination (Landroidx/compose/runtime/Composer;I)Landroidx/navigation/NavDestination;
 	public final fun getFloatingButtonView ()Ldev/teogor/ceres/framework/core/screen/FloatingButtonView;
 	public final fun getNavController ()Landroidx/navigation/NavHostController;
+	public final fun getNavigationItems ()Ljava/util/List;
 	public final fun getScreenInfo ()Ldev/teogor/ceres/framework/core/screen/ScreenInfo;
 	public final fun getShouldShowBottomBar ()Z
 	public final fun getShouldShowNavBar ()Z
 	public final fun getShouldShowNavRail ()Z
 	public final fun getSnackbarView ()Ldev/teogor/ceres/framework/core/screen/SnackbarView;
 	public final fun getToolbarTokens ()Ldev/teogor/ceres/framework/core/screen/ToolbarTokens;
-	public final fun getTopLevelDestinations ()Ljava/util/List;
 	public final fun getWindowSizeClass ()Landroidx/compose/material3/windowsizeclass/WindowSizeClass;
 	public final fun isNavigationBarVisible ()Z
 	public final fun isOffline ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun isStatusBarVisible ()Z
-	public final fun navigateToTopLevelDestination (Ldev/teogor/ceres/navigation/core/menu/TopLevelDestination;)V
+	public final fun navigateToNavigationItem (Ldev/teogor/ceres/navigation/core/models/NavigationItem;)V
 	public final fun setFloatingButtonView (Ldev/teogor/ceres/framework/core/screen/FloatingButtonView;)V
 	public final fun setNavigationBarVisible (Z)V
 	public final fun setShouldShowNavBar (Z)V

--- a/framework/core/src/main/kotlin/dev/teogor/ceres/framework/core/Activity.kt
+++ b/framework/core/src/main/kotlin/dev/teogor/ceres/framework/core/Activity.kt
@@ -59,7 +59,7 @@ import dev.teogor.ceres.monetisation.ads.LocalAdsControl
 import dev.teogor.ceres.navigation.core.LocalNavigationParameters
 import dev.teogor.ceres.navigation.core.NavigationParameters
 import dev.teogor.ceres.navigation.core.ScreenRoute
-import dev.teogor.ceres.navigation.core.menu.TopLevelDestination
+import dev.teogor.ceres.navigation.core.models.NavigationItem
 import dev.teogor.ceres.ui.foundation.config.FeedbackConfig
 import dev.teogor.ceres.ui.theme.core.Theme
 import javax.inject.Inject
@@ -86,7 +86,7 @@ open class Activity : ComponentActivity() {
   @Inject
   lateinit var crashlyticsHelper: CrashlyticsHelper
 
-  open val topLevelDestinations: List<TopLevelDestination> = emptyList()
+  open val navigationItems: List<NavigationItem> = emptyList()
 
   open fun handleUriVariants(uri: Uri): ScreenRoute? = null
 
@@ -225,7 +225,7 @@ open class Activity : ComponentActivity() {
           CeresApp(
             windowSizeClass = calculateWindowSizeClass(this),
             networkMonitor = networkMonitor,
-            topLevelDestinations = topLevelDestinations,
+            navigationItems = navigationItems,
             menuSheetContent = menuConfigContent,
             headerContent = menuConfigHeader,
           ) { windowSizeClass, ceresAppState, baseActions, padding ->

--- a/framework/core/src/main/kotlin/dev/teogor/ceres/framework/core/app/CeresApp.kt
+++ b/framework/core/src/main/kotlin/dev/teogor/ceres/framework/core/app/CeresApp.kt
@@ -81,7 +81,7 @@ import dev.teogor.ceres.navigation.core.LocalNavigationParameters
 import dev.teogor.ceres.navigation.core.lib.common.BottomSheetState
 import dev.teogor.ceres.navigation.core.lib.common.LocalBottomSheetVM
 import dev.teogor.ceres.navigation.core.lib.common.rememberNavigationModules
-import dev.teogor.ceres.navigation.core.menu.TopLevelDestination
+import dev.teogor.ceres.navigation.core.models.NavigationItem
 import dev.teogor.ceres.ui.compose.LocalToolbarState
 import dev.teogor.ceres.ui.compose.ToolbarState
 import dev.teogor.ceres.ui.designsystem.CeresBackground
@@ -117,11 +117,11 @@ import kotlinx.coroutines.launch
 fun CeresApp(
   windowSizeClass: WindowSizeClass,
   networkMonitor: NetworkMonitor,
-  topLevelDestinations: List<TopLevelDestination> = listOf(),
+  navigationItems: List<NavigationItem> = listOf(),
   appState: CeresAppState = rememberCeresAppState(
     networkMonitor = networkMonitor,
     windowSizeClass = windowSizeClass,
-    topLevelDestinations = topLevelDestinations,
+    navigationItems = navigationItems,
   ),
   baseActions: BaseActions = remember {
     BaseActions(appState)
@@ -272,7 +272,7 @@ fun CeresApp(
               }
             },
             bottomBar = {
-              if (topLevelDestinations.isNotEmpty()) {
+              if (navigationItems.isNotEmpty()) {
                 val bottomBarVisible = rememberSaveable(
                   bottomSheetVisible.value,
                   appState.shouldShowBottomBar,
@@ -282,8 +282,8 @@ fun CeresApp(
                 }
                 if (bottomBarVisible) {
                   CeresBottomBar(
-                    destinations = appState.topLevelDestinations,
-                    onNavigateToDestination = appState::navigateToTopLevelDestination,
+                    destinations = appState.navigationItems,
+                    onNavigateToDestination = appState::navigateToNavigationItem,
                     currentDestination = appState.currentDestination,
                     modifier = Modifier.testTag("CeresBottomBar"),
                   )
@@ -352,11 +352,11 @@ fun CeresApp(
             },
           ) { padding ->
             val innerPadding = padding.calculateInnerPadding()
-            if (topLevelDestinations.isNotEmpty()) {
+            if (navigationItems.isNotEmpty()) {
               if (!navigationModules.bottomNav.isVisible() && appState.shouldShowNavRail && appState.shouldShowNavBar) {
                 CeresNavRail(
-                  destinations = appState.topLevelDestinations,
-                  onNavigateToDestination = appState::navigateToTopLevelDestination,
+                  destinations = appState.navigationItems,
+                  onNavigateToDestination = appState::navigateToNavigationItem,
                   currentDestination = appState.currentDestination,
                   modifier = Modifier
                     .testTag("CeresNavRail")
@@ -466,14 +466,14 @@ fun PaddingValues.calculateInnerPadding(
 
 @Composable
 private fun CeresNavRail(
-  destinations: List<TopLevelDestination>,
-  onNavigateToDestination: (TopLevelDestination) -> Unit,
+  destinations: List<NavigationItem>,
+  onNavigateToDestination: (NavigationItem) -> Unit,
   currentDestination: NavDestination?,
   modifier: Modifier = Modifier,
 ) {
   CeresNavigationRail(modifier = modifier) {
     destinations.forEach { destination ->
-      val selected = currentDestination.isTopLevelDestinationInHierarchy(destination)
+      val selected = currentDestination.isNavigationItemInHierarchy(destination)
       CeresNavigationRailItem(
         selected = selected,
         onClick = { onNavigateToDestination(destination) },
@@ -503,8 +503,8 @@ private fun CeresNavRail(
 
 @Composable
 private fun CeresBottomBar(
-  destinations: List<TopLevelDestination>,
-  onNavigateToDestination: (TopLevelDestination) -> Unit,
+  destinations: List<NavigationItem>,
+  onNavigateToDestination: (NavigationItem) -> Unit,
   currentDestination: NavDestination?,
   modifier: Modifier = Modifier,
 ) {
@@ -512,7 +512,7 @@ private fun CeresBottomBar(
     modifier = modifier,
   ) {
     destinations.forEach { destination ->
-      val selected = currentDestination.isTopLevelDestinationInHierarchy(destination)
+      val selected = currentDestination.isNavigationItemInHierarchy(destination)
       CeresNavigationBarItem(
         selected = selected,
         onClick = { onNavigateToDestination(destination) }.withTouchFeedback(LocalContext.current),
@@ -541,7 +541,7 @@ private fun CeresBottomBar(
   }
 }
 
-private fun NavDestination?.isTopLevelDestinationInHierarchy(destination: TopLevelDestination) =
+private fun NavDestination?.isNavigationItemInHierarchy(destination: NavigationItem) =
   this?.hierarchy?.any {
-    destination.screenRoute?.let { it1 -> it.route?.contains(it1.route, true) } ?: false
+    destination.screenRoute.let { it1 -> it.route?.contains(it1.route, true) } ?: false
   } ?: false

--- a/framework/core/src/main/kotlin/dev/teogor/ceres/framework/core/app/CeresAppState.kt
+++ b/framework/core/src/main/kotlin/dev/teogor/ceres/framework/core/app/CeresAppState.kt
@@ -40,7 +40,7 @@ import dev.teogor.ceres.core.startup.ApplicationContextProvider
 import dev.teogor.ceres.framework.core.screen.ScreenInfo
 import dev.teogor.ceres.framework.core.screen.rememberScreenInfo
 import dev.teogor.ceres.navigation.core.isRouteInBackStack
-import dev.teogor.ceres.navigation.core.menu.TopLevelDestination
+import dev.teogor.ceres.navigation.core.models.NavigationItem
 import dev.teogor.ceres.ui.foundation.lib.tools.TrackDisposableJank
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
@@ -54,7 +54,7 @@ fun rememberCeresAppState(
   coroutineScope: CoroutineScope = rememberCoroutineScope(),
   navController: NavHostController = rememberNavController(),
   screenInfo: ScreenInfo = rememberScreenInfo(),
-  topLevelDestinations: List<TopLevelDestination>,
+  navigationItems: List<NavigationItem>,
 ): CeresAppState {
   NavigationTrackingSideEffect(navController)
   return remember(
@@ -63,7 +63,7 @@ fun rememberCeresAppState(
     windowSizeClass,
     screenInfo,
     networkMonitor,
-    topLevelDestinations,
+    navigationItems,
   ) {
     CeresAppState(
       navController,
@@ -71,7 +71,7 @@ fun rememberCeresAppState(
       windowSizeClass,
       screenInfo,
       networkMonitor,
-      topLevelDestinations,
+      navigationItems,
     )
   }
 }
@@ -83,7 +83,7 @@ class CeresAppState(
   val windowSizeClass: WindowSizeClass,
   val screenInfo: ScreenInfo,
   networkMonitor: NetworkMonitor,
-  topLevelDestinations: List<TopLevelDestination>,
+  navigationItems: List<NavigationItem>,
 ) {
   val currentDestination: NavDestination?
     @Composable get() = navController.currentBackStackEntryAsState().value?.destination
@@ -119,18 +119,18 @@ class CeresAppState(
    * Map of top level destinations to be used in the TopBar, BottomBar and NavRail. The key is the
    * route.
    */
-  val topLevelDestinations: List<TopLevelDestination> = topLevelDestinations
+  val navigationItems: List<NavigationItem> = navigationItems
 
   /**
    * UI logic for navigating to a top level destination in the app. Top level destinations have
    * only one copy of the destination of the back stack, and save and restore state whenever you
    * navigate to and from it.
    *
-   * @param topLevelDestination: The destination the app needs to navigate to.
+   * @param navigationItem: The destination the app needs to navigate to.
    */
-  fun navigateToTopLevelDestination(topLevelDestination: TopLevelDestination) {
-    trace("Navigation: ${topLevelDestination.titleText.lowercase()}") {
-      topLevelDestination.screenRoute?.let { destination ->
+  fun navigateToNavigationItem(navigationItem: NavigationItem) {
+    trace("Navigation: ${navigationItem.titleText.lowercase()}") {
+      navigationItem.screenRoute.let { destination ->
         val isExisting = navController.isRouteInBackStack(destination.route)
         // todo let users decide
         val enableSingleInstance = true
@@ -155,13 +155,13 @@ class CeresAppState(
           }
 
           // Navigate to the destination with the specified navigation options
-          when (topLevelDestination) {
-            in topLevelDestinations -> navController.navigate(
+          when (navigationItem) {
+            in navigationItems -> navController.navigate(
               destination.route,
               topLevelNavOptions,
             )
 
-            else -> Log.e("AppState", "Invalid TopLevelDestination: $topLevelDestination")
+            else -> Log.e("AppState", "Invalid NavigationItem: $navigationItem")
           }
         }
       }

--- a/navigation/core/api/core.api
+++ b/navigation/core/api/core.api
@@ -91,6 +91,17 @@ public class dev/teogor/ceres/navigation/core/menu/TopLevelDestination {
 	public final fun getUnselectedIcon ()Ldev/teogor/ceres/ui/foundation/graphics/Icon;
 }
 
+public class dev/teogor/ceres/navigation/core/models/NavigationItem {
+	public static final field $stable I
+	public fun <init> (Ldev/teogor/ceres/ui/foundation/graphics/Icon;Ldev/teogor/ceres/ui/foundation/graphics/Icon;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/ceres/navigation/core/ScreenRoute;)V
+	public synthetic fun <init> (Ldev/teogor/ceres/ui/foundation/graphics/Icon;Ldev/teogor/ceres/ui/foundation/graphics/Icon;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/ceres/navigation/core/ScreenRoute;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getIconText ()Ljava/lang/String;
+	public final fun getScreenRoute ()Ldev/teogor/ceres/navigation/core/ScreenRoute;
+	public final fun getSelectedIcon ()Ldev/teogor/ceres/ui/foundation/graphics/Icon;
+	public final fun getTitleText ()Ljava/lang/String;
+	public final fun getUnselectedIcon ()Ldev/teogor/ceres/ui/foundation/graphics/Icon;
+}
+
 public final class dev/teogor/ceres/navigation/core/utilities/RouteExtensionsKt {
 	public static final fun toScreenName (Ldev/teogor/ceres/navigation/core/ScreenRoute;)Ljava/lang/String;
 }

--- a/navigation/core/src/main/kotlin/dev/teogor/ceres/navigation/core/models/NavigationItem.kt
+++ b/navigation/core/src/main/kotlin/dev/teogor/ceres/navigation/core/models/NavigationItem.kt
@@ -14,19 +14,22 @@
  * limitations under the License.
  */
 
-package dev.teogor.ceres.navigation.core.menu
+package dev.teogor.ceres.navigation.core.models
 
 import dev.teogor.ceres.navigation.core.ScreenRoute
 import dev.teogor.ceres.ui.foundation.graphics.Icon
 
-@Deprecated(
-  "Use NavigationItem instead",
-  ReplaceWith(
-    "NavigationItem",
-    "dev.teogor.ceres.navigation.core.models.NavigationItem",
-  ),
-)
-open class TopLevelDestination(
+/**
+ * Represents a navigation item used in a bottom navigation bar, tab bar, or similar UI components.
+ * This class encapsulates the properties needed to define a navigation item.
+ *
+ * @param selectedIcon The icon to display when this item is selected.
+ * @param unselectedIcon The icon to display when this item is not selected.
+ * @param titleText The text to display as the title or label for this item.
+ * @param iconText The text to display as the icon's label (defaults to [titleText]).
+ * @param screenRoute The route to the screen that is visible when this item is active.
+ */
+open class NavigationItem(
   val selectedIcon: Icon,
   val unselectedIcon: Icon,
   val titleText: String,


### PR DESCRIPTION
This PR introduces a new `NavigationItem` class that represents a navigation item, commonly used in bottom navigation bars, tab bars, or similar UI components within the Ceres project.

## Changes Made
- Added the `NavigationItem` class in the `dev.teogor.ceres.navigation.core.models` package.
- The class encapsulates essential properties required to define a navigation item, including:
  - `selectedIcon`: The icon to display when the item is selected.
  - `unselectedIcon`: The icon to display when the item is not selected.
  - `titleText`: The text to display as the title or label for the item.
  - `iconText`: The text to display as the icon's label, which defaults to the `titleText`.
  - `screenRoute`: The route to the screen that is visible when this item is active.

## Context
This new `NavigationItem` class provides a standardized way to represent navigation items across various UI components within the Ceres project. It offers flexibility in customizing the appearance and behavior of these items while maintaining consistency in the way they are defined.

## Usage Examples
Here are some typical use cases for the `NavigationItem` class:

```kotlin
val homeItem = NavigationItem(
    selectedIcon = Icons.Default.Home,
    unselectedIcon = Icons.Default.Home,
    titleText = "Home",
    screenRoute = ScreenRoute.Home
)

val profileItem = NavigationItem(
    selectedIcon = Icons.Default.Person,
    unselectedIcon = Icons.Default.PersonOutline,
    titleText = "Profile",
    screenRoute = ScreenRoute.Profile
)
```