### PR TITLE
Fixed App Open Ad Display on App Resume

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,7 +103,9 @@ androidx-dataStore-core = { group = "androidx.datastore", name = "datastore", ve
 androidx-dataStore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDataStore" }
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "androidxHiltNavigationCompose" }
 androidx-lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "androidxLifecycle" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtimeCompose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewModelCompose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-metrics = { group = "androidx.metrics", name = "metrics-performance", version.ref = "androidxMetrics" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxNavigation" }

--- a/monetisation/admob/build.gradle.kts
+++ b/monetisation/admob/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
 
   implementation("io.github.farimarwat:admobnative-compose:1.2")
 
+  implementation(libs.androidx.lifecycle.process)
+
   api(project(":monetisation:ads"))
   implementation(project(":core:runtime"))
   implementation(project(":core:network"))

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/AdmobManagerInitializer.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/AdmobManagerInitializer.kt
@@ -47,7 +47,7 @@ class AdmobManagerInitializer : Initializer<Unit> {
       )
       AdMobInitializer.initialize(context)
     }
-    CurrentActivityManager(context)
+    AdMobLifecycleManager(context)
   }
 
   override fun dependencies() = emptyList<Class<out Initializer<*>?>>()


### PR DESCRIPTION
To fix this issue, the following changes have been made:
- The `CurrentActivityManager` class now implements `DefaultLifecycleObserver`, and the `onStart` method is used to trigger the display of App Open Ads.
- The `onActivityResumed` method, which previously handled ad display logic, has been simplified to update the current activity in the `CurrentActivityHolder` without triggering ad display.
- The logic for displaying App Open Ads is now centralized in the `showAppOpenAd` method, which is called from `onStart`.

These changes ensure that App Open Ads are displayed correctly when the application is resumed from the background, as intended.

closes #123 
