### PR TITLE
Feature: CompositionLocal Configuration with compositionProviders

### DIFF
--- a/app/src/main/kotlin/dev/teogor/ceres/MainActivity.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/MainActivity.kt
@@ -17,6 +17,7 @@
 package dev.teogor.ceres
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidedValue
 import dagger.hilt.android.AndroidEntryPoint
 import dev.teogor.ceres.framework.core.Activity
 import dev.teogor.ceres.framework.core.model.MenuConfig
@@ -59,4 +60,14 @@ class MainActivity : Activity() {
    */
   @Composable
   override fun MenuConfig.buildMenu() = applyMenuConfig()
+
+  /**
+   * Provides a list of [ProvidedValue] instances that can be used to initialize CompositionLocal values.
+   *
+   * @return A list of [ProvidedValue] instances.
+   */
+  @Composable
+  override fun compositionProviders(): List<ProvidedValue<*>> {
+    return listOf()
+  }
 }

--- a/framework/core/api/core.api
+++ b/framework/core/api/core.api
@@ -7,6 +7,7 @@ public class dev/teogor/ceres/framework/core/Activity : androidx/activity/Compon
 	public fun <init> ()V
 	public fun BuildNavGraph (Ldev/teogor/ceres/framework/core/model/NavGraphOptions;Landroidx/compose/runtime/Composer;I)V
 	public fun buildMenu (Ldev/teogor/ceres/framework/core/model/MenuConfig;Landroidx/compose/runtime/Composer;I)Ldev/teogor/ceres/framework/core/model/MenuConfig;
+	public fun compositionProviders (Landroidx/compose/runtime/Composer;I)Ljava/util/List;
 	public final fun getAnalyticsHelper ()Ldev/teogor/ceres/firebase/analytics/AnalyticsHelper;
 	public final fun getCrashlyticsHelper ()Ldev/teogor/ceres/firebase/crashlytics/CrashlyticsHelper;
 	public final fun getLazyStats ()Ldagger/Lazy;

--- a/framework/core/src/main/kotlin/dev/teogor/ceres/framework/core/Activity.kt
+++ b/framework/core/src/main/kotlin/dev/teogor/ceres/framework/core/Activity.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -215,6 +216,8 @@ open class Activity : ComponentActivity() {
 
           // Ceres Monetisation
           LocalAdsControl provides adsControl,
+
+          *compositionProviders().toTypedArray(),
         ) {
           val menuConfig = MenuConfig().apply { buildMenu() }
           val menuConfigHeader =
@@ -242,6 +245,14 @@ open class Activity : ComponentActivity() {
 
     handleIntent(intent)
   }
+
+  /**
+   * Provides a list of [ProvidedValue] instances that can be used to initialize CompositionLocal values.
+   *
+   * @return A list of [ProvidedValue] instances.
+   */
+  @Composable
+  open fun compositionProviders(): List<ProvidedValue<*>> = emptyList()
 
   private fun handleSplashScreen(splashScreen: SplashScreen) {
     // Keep the splash screen on-screen until the UI state is loaded. This condition is


### PR DESCRIPTION
This PR introduces the `compositionProviders` function, a feature that enables CompositionLocal configuration for the application. The function provides a list of `ProvidedValue` instances, allowing developers to initialize CompositionLocal values.

Here are the key points of this PR:
- Added the `compositionProviders` function to the base class.
- The default implementation returns an empty list but can be customized in derived classes.
- This change sets the stage for fine-grained control over CompositionLocal values in future updates.

closes #124 