### PR TITLE
Added Privacy Navigation and Screen

### DIFF
--- a/app/src/main/kotlin/dev/teogor/ceres/MainActivity.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/MainActivity.kt
@@ -19,6 +19,8 @@ package dev.teogor.ceres
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidedValue
 import dagger.hilt.android.AndroidEntryPoint
+import dev.teogor.ceres.core.foundation.ui.platform.DefaultApplicationDetails
+import dev.teogor.ceres.core.foundation.ui.platform.LocalApplicationDetails
 import dev.teogor.ceres.framework.core.Activity
 import dev.teogor.ceres.framework.core.model.MenuConfig
 import dev.teogor.ceres.framework.core.model.NavGraphOptions
@@ -68,6 +70,14 @@ class MainActivity : Activity() {
    */
   @Composable
   override fun compositionProviders(): List<ProvidedValue<*>> {
-    return listOf()
+    return listOf(
+      LocalApplicationDetails provides DefaultApplicationDetails(
+        appName = "Ceres",
+        privacyEmail = "privacy@zeoowl.com",
+        supportEmail = "support@zeoowl.com",
+        privacyLink = "https://privacy.zeoowl.com",
+        termsLink = "https://terms.zeoowl.com",
+      ),
+    )
   }
 }

--- a/app/src/main/kotlin/dev/teogor/ceres/feature/home/HomeScreen.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/feature/home/HomeScreen.kt
@@ -56,9 +56,7 @@ import dev.teogor.ceres.monetisation.admob.formats.nativead.createCallToActionVi
 import dev.teogor.ceres.monetisation.admob.formats.nativead.createHeadlineView
 import dev.teogor.ceres.monetisation.admob.formats.nativead.createIconView
 import dev.teogor.ceres.monetisation.ads.ExperimentalAdsControlApi
-import dev.teogor.ceres.monetisation.ads.LocalAdsControl
 import dev.teogor.ceres.monetisation.messaging.ConsentManager
-import dev.teogor.ceres.monetisation.messaging.ConsentResult
 import dev.teogor.ceres.navigation.core.LocalNavigationParameters
 import dev.teogor.ceres.navigation.core.utilities.toScreenName
 import dev.teogor.ceres.screen.builder.compose.HeaderView
@@ -75,15 +73,6 @@ internal fun HomeRoute(
   baseActions: BaseActions,
   homeVM: HomeViewModel = hiltViewModel(),
 ) {
-  val state by remember { ConsentManager.state }
-  val canRequestAds: Boolean = remember(state) {
-    when (val consentResult = state) {
-      is ConsentResult.ConsentFormAcquired -> consentResult.canRequestAds
-      is ConsentResult.ConsentFormDismissed -> consentResult.canRequestAds
-      else -> false
-    }
-  }
-
   baseActions.setScreenInfo {
     showNavBar {
       true
@@ -156,49 +145,6 @@ private fun HomeScreen(
   hasScrollbarBackground = false,
   screenName = HomeScreenConfig.toScreenName(),
 ) {
-  HeaderView(title = "Ad Settings")
-
-  SimpleView(
-    title = "Reset Advertising Choices",
-    subtitle = "Reset your advertising choices to manage your options.",
-    clickable = {
-      ConsentManager.resetConsent()
-    },
-  )
-
-  val handleOnboardingReset = handleOnboardingReset()
-  SimpleView(
-    title = "Reset Onboarding",
-    clickable = {
-      handleOnboardingReset()
-    },
-  )
-
-  HeaderView(title = "Ads Control")
-
-  val adsControl = LocalAdsControl.current
-  val canRequestAds by remember { adsControl.canRequestAds }
-  SimpleView(
-    title = "Can Request Ads",
-    subtitle = "$canRequestAds",
-    clickable = {
-    },
-  )
-  val consentStatus by remember { adsControl.consentStatus }
-  SimpleView(
-    title = "Consent Status",
-    subtitle = consentStatus.name,
-    clickable = {
-    },
-  )
-  val consentRequirementStatus by remember { adsControl.consentRequirementStatus }
-  SimpleView(
-    title = "Consent Requirement Status",
-    subtitle = consentRequirementStatus.name,
-    clickable = {
-    },
-  )
-
   HeaderView(title = "Ads Demo")
 
   // customView {

--- a/app/src/main/kotlin/dev/teogor/ceres/feature/privacy/PrivacyNavigation.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/feature/privacy/PrivacyNavigation.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.feature.privacy
+
+import androidx.navigation.NavGraphBuilder
+import dev.teogor.ceres.framework.core.app.BaseActions
+import dev.teogor.ceres.screen.ui.privacy.privacyOptionsNavPath
+
+fun NavGraphBuilder.privacyOptionsNavPath(
+  baseActions: BaseActions,
+) = privacyOptionsNavPath {
+  PrivacyOptionsRoute(
+    baseActions = baseActions,
+  )
+}

--- a/app/src/main/kotlin/dev/teogor/ceres/feature/privacy/PrivacyScreen.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/feature/privacy/PrivacyScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dev.teogor.ceres.feature.settings
+package dev.teogor.ceres.feature.privacy
 
 import androidx.compose.runtime.Composable
 import dev.teogor.ceres.framework.core.app.BaseActions
@@ -29,14 +29,19 @@ import dev.teogor.ceres.framework.core.screen.toolbarTitle
 import dev.teogor.ceres.framework.core.screen.toolbarTokens
 import dev.teogor.ceres.navigation.core.utilities.toScreenName
 import dev.teogor.ceres.screen.core.layout.LazyColumnLayoutBase
-import dev.teogor.ceres.screen.ui.settings.SettingsScreenRoute
-import dev.teogor.ceres.screen.ui.settings.settingsHeaderDataPrivacy
-import dev.teogor.ceres.screen.ui.settings.settingsHeaderUI
-import dev.teogor.ceres.screen.ui.settings.settingsLookAndFeel
-import dev.teogor.ceres.screen.ui.settings.settingsPrivacyOptions
+import dev.teogor.ceres.screen.ui.privacy.PrivacyOptionsRoute
+import dev.teogor.ceres.screen.ui.privacy.legalAgreementsHeader
+import dev.teogor.ceres.screen.ui.privacy.policyAppLicensePolicy
+import dev.teogor.ceres.screen.ui.privacy.policyCopyrightPolicy
+import dev.teogor.ceres.screen.ui.privacy.privacyOptionsHeader
+import dev.teogor.ceres.screen.ui.privacy.privacyPolicyOption
+import dev.teogor.ceres.screen.ui.privacy.privacyResetOnboarding
+import dev.teogor.ceres.screen.ui.privacy.privacyUserId
+import dev.teogor.ceres.screen.ui.privacy.resetAdsConsentOption
+import dev.teogor.ceres.screen.ui.privacy.termsOfServiceOption
 
 @Composable
-internal fun SettingsRoute(
+internal fun PrivacyOptionsRoute(
   baseActions: BaseActions,
 ) {
   baseActions.setScreenInfo {
@@ -48,7 +53,7 @@ internal fun SettingsRoute(
     }
     toolbarTokens {
       toolbarTitle {
-        "Settings"
+        "Privacy Options"
       }
       showSettingsButton {
         false
@@ -65,22 +70,30 @@ internal fun SettingsRoute(
     }
   }
 
-  SettingsLayout()
+  PrivacyOptionsLayout()
 }
 
 @Composable
-private fun SettingsLayout() = LazyColumnLayoutBase(
-  screenName = SettingsScreenRoute.toScreenName(),
+private fun PrivacyOptionsLayout() = LazyColumnLayoutBase(
+  screenName = PrivacyOptionsRoute.toScreenName(),
 ) {
-  settingsHeaderUI()
+  privacyOptionsHeader()
 
-  settingsLookAndFeel()
+  resetAdsConsentOption()
 
-  // settingsBackup()
+  privacyUserId()
 
-  // settingsHeaderSystem()
+  privacyResetOnboarding()
 
-  settingsHeaderDataPrivacy()
+  legalAgreementsHeader()
 
-  settingsPrivacyOptions()
+  privacyPolicyOption()
+
+  termsOfServiceOption()
+
+  policyCopyrightPolicy()
+
+  // policyRefundPolicy()
+
+  policyAppLicensePolicy()
 }

--- a/app/src/main/kotlin/dev/teogor/ceres/menu/Menu.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/menu/Menu.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import dev.teogor.ceres.core.foundation.ui.platform.LocalApplicationDetails
 import dev.teogor.ceres.framework.core.menu.MenuTitle
 import dev.teogor.ceres.framework.core.menu.menu
 import dev.teogor.ceres.framework.core.menu.menuContent
@@ -49,6 +50,7 @@ import dev.teogor.ceres.screen.ui.userprefs.UserPreferencesScreenRoute
 @Composable
 fun MenuConfig.applyMenuConfig() = apply {
   val navigationParameters = LocalNavigationParameters.current
+  val applicationDetails = LocalApplicationDetails.current
 
   // Extension function to navigate to a screen route
   fun ScreenRoute.navigateTo() {
@@ -58,7 +60,7 @@ fun MenuConfig.applyMenuConfig() = apply {
   // Set the header content
   headerContent = {
     MenuTitle(
-      title = "Ceres",
+      title = applicationDetails.appName ?: "",
     )
   }
 

--- a/app/src/main/kotlin/dev/teogor/ceres/navigation/Navigation.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/navigation/Navigation.kt
@@ -27,6 +27,7 @@ import dev.teogor.ceres.feature.home.HomeScreenConfig
 import dev.teogor.ceres.feature.home.homeScreenNav
 import dev.teogor.ceres.feature.lookandfeel.lookAndFeelScreenNav
 import dev.teogor.ceres.feature.onboarding.onboardingScreenNav
+import dev.teogor.ceres.feature.privacy.privacyOptionsNavPath
 import dev.teogor.ceres.feature.settings.settingsScreenNav
 import dev.teogor.ceres.framework.core.app.BaseActions
 import dev.teogor.ceres.framework.core.app.CeresAppState
@@ -97,6 +98,8 @@ private fun NavHost(
       settingsScreenNav(baseActions)
 
       lookAndFeelScreenNav(baseActions)
+
+      privacyOptionsNavPath(baseActions)
     }
 
     aboutGraphNav(baseActions) {

--- a/core/foundation/api/foundation.api
+++ b/core/foundation/api/foundation.api
@@ -279,6 +279,40 @@ public final class dev/teogor/ceres/core/foundation/extensions/MediaPlayerExtKt 
 	public static final fun createMediaPlayer (Landroid/net/Uri;Landroid/view/SurfaceHolder;Landroid/media/AudioAttributes;ILandroidx/compose/runtime/Composer;II)Landroid/media/MediaPlayer;
 }
 
+public abstract interface class dev/teogor/ceres/core/foundation/ui/platform/ApplicationDetails {
+	public abstract fun getAppName ()Ljava/lang/String;
+	public abstract fun getPrivacyEmail ()Ljava/lang/String;
+	public abstract fun getPrivacyLink ()Ljava/lang/String;
+	public abstract fun getSupportEmail ()Ljava/lang/String;
+	public abstract fun getTermsLink ()Ljava/lang/String;
+}
+
+public final class dev/teogor/ceres/core/foundation/ui/platform/ApplicationDetailsKt {
+	public static final fun getLocalApplicationDetails ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class dev/teogor/ceres/core/foundation/ui/platform/DefaultApplicationDetails : dev/teogor/ceres/core/foundation/ui/platform/ApplicationDetails {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ldev/teogor/ceres/core/foundation/ui/platform/DefaultApplicationDetails;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/core/foundation/ui/platform/DefaultApplicationDetails;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/ceres/core/foundation/ui/platform/DefaultApplicationDetails;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAppName ()Ljava/lang/String;
+	public fun getPrivacyEmail ()Ljava/lang/String;
+	public fun getPrivacyLink ()Ljava/lang/String;
+	public fun getSupportEmail ()Ljava/lang/String;
+	public fun getTermsLink ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class dev/teogor/ceres/core/foundation/utils/ErrorCompositionLocalKt {
 	public static final fun errorCompositionLocal (Ljava/lang/String;)Ljava/lang/Void;
 }

--- a/core/foundation/src/main/kotlin/dev/teogor/ceres/core/foundation/ui/platform/ApplicationDetails.kt
+++ b/core/foundation/src/main/kotlin/dev/teogor/ceres/core/foundation/ui/platform/ApplicationDetails.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.core.foundation.ui.platform
+
+import androidx.compose.runtime.compositionLocalOf
+
+data class DefaultApplicationDetails(
+  override val privacyEmail: String? = null,
+  override val supportEmail: String? = null,
+  override val privacyLink: String? = null,
+  override val termsLink: String? = null,
+  override val appName: String? = null,
+) : ApplicationDetails
+
+val LocalApplicationDetails = compositionLocalOf<ApplicationDetails> {
+  DefaultApplicationDetails()
+}
+
+interface ApplicationDetails {
+  val privacyEmail: String?
+  val supportEmail: String?
+  val privacyLink: String?
+  val termsLink: String?
+  val appName: String?
+}

--- a/monetisation/ads/api/ads.api
+++ b/monetisation/ads/api/ads.api
@@ -2,6 +2,7 @@ public abstract interface class dev/teogor/ceres/monetisation/ads/AdsControl {
 	public abstract fun getCanRequestAds ()Landroidx/compose/runtime/MutableState;
 	public abstract fun getConsentRequirementStatus ()Landroidx/compose/runtime/MutableState;
 	public abstract fun getConsentStatus ()Landroidx/compose/runtime/MutableState;
+	public abstract fun resetConsent ()V
 	public abstract fun showConsent ()V
 }
 
@@ -24,20 +25,23 @@ public final class dev/teogor/ceres/monetisation/ads/AdsControlProvider {
 public final class dev/teogor/ceres/monetisation/ads/AndroidAdsControl : dev/teogor/ceres/monetisation/ads/AdsControl {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Landroidx/compose/runtime/MutableState;
 	public final fun component2 ()Landroidx/compose/runtime/MutableState;
 	public final fun component3 ()Landroidx/compose/runtime/MutableState;
 	public final fun component4 ()Lkotlin/jvm/functions/Function0;
-	public final fun copy (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;)Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;
+	public final fun component5 ()Lkotlin/jvm/functions/Function0;
+	public final fun copy (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCanRequestAds ()Landroidx/compose/runtime/MutableState;
 	public fun getConsentRequirementStatus ()Landroidx/compose/runtime/MutableState;
 	public fun getConsentStatus ()Landroidx/compose/runtime/MutableState;
+	public final fun getResetConsent ()Lkotlin/jvm/functions/Function0;
 	public final fun getShowConsent ()Lkotlin/jvm/functions/Function0;
 	public fun hashCode ()I
+	public fun resetConsent ()V
 	public fun showConsent ()V
 	public fun toString ()Ljava/lang/String;
 }

--- a/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/AdsControl.kt
+++ b/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/AdsControl.kt
@@ -41,6 +41,7 @@ data class AndroidAdsControl(
     ConsentRequirementStatus.UNKNOWN,
   ),
   val showConsent: (() -> Unit)? = null,
+  val resetConsent: (() -> Unit)? = null,
 ) : AdsControl {
 
   override fun showConsent() {
@@ -49,8 +50,16 @@ data class AndroidAdsControl(
     }
     showConsent.invoke()
   }
+
+  override fun resetConsent() {
+    requireNotNull(resetConsent) {
+      "The 'showConsent' function must be provided when creating an instance of AndroidAdsControl."
+    }
+    resetConsent.invoke()
+  }
 }
 
+@OptIn(ExperimentalAdsControlApi::class)
 val LocalAdsControl = compositionLocalOf<AdsControl> {
   error("No AdsControl provided")
 }
@@ -62,6 +71,8 @@ interface AdsControl {
   val consentRequirementStatus: MutableState<ConsentRequirementStatus>
 
   fun showConsent()
+
+  fun resetConsent()
 }
 
 val AdsControl.shouldShowConsentDialog: Boolean

--- a/monetisation/messaging/src/main/kotlin/dev/teogor/ceres/monetisation/messaging/MessagingManager.kt
+++ b/monetisation/messaging/src/main/kotlin/dev/teogor/ceres/monetisation/messaging/MessagingManager.kt
@@ -36,6 +36,9 @@ class MessagingManager {
           showConsent = {
             ConsentManager.loadAndShowConsentFormIfRequired()
           },
+          resetConsent = {
+            ConsentManager.resetConsent()
+          }
         ),
       )
 

--- a/monetisation/messaging/src/main/kotlin/dev/teogor/ceres/monetisation/messaging/MessagingManager.kt
+++ b/monetisation/messaging/src/main/kotlin/dev/teogor/ceres/monetisation/messaging/MessagingManager.kt
@@ -38,7 +38,7 @@ class MessagingManager {
           },
           resetConsent = {
             ConsentManager.resetConsent()
-          }
+          },
         ),
       )
 

--- a/screen/ui/api/ui.api
+++ b/screen/ui/api/ui.api
@@ -394,24 +394,94 @@ public final class dev/teogor/ceres/screen/ui/onboarding/screens/TermsOfService 
 	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/screens/TermsOfService;
 }
 
+public final class dev/teogor/ceres/screen/ui/privacy/ComposableSingletons$PrivacyScreenKt {
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/privacy/ComposableSingletons$PrivacyScreenKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-10 Lkotlin/jvm/functions/Function3;
+	public static field lambda-11 Lkotlin/jvm/functions/Function2;
+	public static field lambda-12 Lkotlin/jvm/functions/Function3;
+	public static field lambda-13 Lkotlin/jvm/functions/Function3;
+	public static field lambda-14 Lkotlin/jvm/functions/Function3;
+	public static field lambda-15 Lkotlin/jvm/functions/Function3;
+	public static field lambda-16 Lkotlin/jvm/functions/Function3;
+	public static field lambda-17 Lkotlin/jvm/functions/Function3;
+	public static field lambda-18 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-3 Lkotlin/jvm/functions/Function3;
+	public static field lambda-4 Lkotlin/jvm/functions/Function2;
+	public static field lambda-5 Lkotlin/jvm/functions/Function2;
+	public static field lambda-6 Lkotlin/jvm/functions/Function3;
+	public static field lambda-7 Lkotlin/jvm/functions/Function3;
+	public static field lambda-8 Lkotlin/jvm/functions/Function3;
+	public static field lambda-9 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-10$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-11$ui_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-12$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-13$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-14$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-15$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-16$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-17$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-18$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-3$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-4$ui_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-5$ui_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-6$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-7$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-8$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-9$ui_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class dev/teogor/ceres/screen/ui/privacy/PrivacyNavigationKt {
+	public static final fun privacyOptionsNavPath (Landroidx/navigation/NavGraphBuilder;Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class dev/teogor/ceres/screen/ui/privacy/PrivacyOptionsRoute : dev/teogor/ceres/navigation/core/ScreenRoute {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/privacy/PrivacyOptionsRoute;
+	public fun getRoute ()Ljava/lang/String;
+}
+
+public final class dev/teogor/ceres/screen/ui/privacy/PrivacyScreenKt {
+	public static final fun legalAgreementsHeader (Landroidx/compose/foundation/lazy/LazyListScope;)V
+	public static final fun policyAppLicensePolicy (Landroidx/compose/foundation/lazy/LazyListScope;)V
+	public static final fun policyCopyrightPolicy (Landroidx/compose/foundation/lazy/LazyListScope;)V
+	public static final fun policyRefundPolicy (Landroidx/compose/foundation/lazy/LazyListScope;)V
+	public static final fun privacyOptionsHeader (Landroidx/compose/foundation/lazy/LazyListScope;)V
+	public static final fun privacyPolicyOption (Landroidx/compose/foundation/lazy/LazyListScope;)V
+	public static final fun privacyResetOnboarding (Landroidx/compose/foundation/lazy/LazyListScope;)V
+	public static final fun privacyUserId (Landroidx/compose/foundation/lazy/LazyListScope;)V
+	public static final fun resetAdsConsentOption (Landroidx/compose/foundation/lazy/LazyListScope;)V
+	public static final fun termsOfServiceOption (Landroidx/compose/foundation/lazy/LazyListScope;)V
+}
+
 public final class dev/teogor/ceres/screen/ui/settings/ComposableSingletons$SettingsComponentsKt {
 	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/settings/ComposableSingletons$SettingsComponentsKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
 	public static field lambda-2 Lkotlin/jvm/functions/Function3;
 	public static field lambda-3 Lkotlin/jvm/functions/Function3;
 	public static field lambda-4 Lkotlin/jvm/functions/Function3;
+	public static field lambda-5 Lkotlin/jvm/functions/Function3;
+	public static field lambda-6 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
 	public final fun getLambda-1$ui_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-2$ui_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-3$ui_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-4$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-5$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-6$ui_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class dev/teogor/ceres/screen/ui/settings/SettingsComponentsKt {
 	public static final fun settingsBackup (Landroidx/compose/foundation/lazy/LazyListScope;)V
+	public static final fun settingsHeaderDataPrivacy (Landroidx/compose/foundation/lazy/LazyListScope;)V
 	public static final fun settingsHeaderSystem (Landroidx/compose/foundation/lazy/LazyListScope;)V
 	public static final fun settingsHeaderUI (Landroidx/compose/foundation/lazy/LazyListScope;)V
 	public static final fun settingsLookAndFeel (Landroidx/compose/foundation/lazy/LazyListScope;)V
+	public static final fun settingsPrivacyOptions (Landroidx/compose/foundation/lazy/LazyListScope;)V
 }
 
 public final class dev/teogor/ceres/screen/ui/settings/SettingsNavigationKt {
@@ -447,5 +517,10 @@ public final class dev/teogor/ceres/screen/ui/userprefs/UserPrefsNaviagtionKt {
 
 public final class dev/teogor/ceres/screen/ui/userprefs/UserPrefsScreenKt {
 	public static final fun UserPrefScreen (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class dev/teogor/ceres/screen/ui/utils/InvokersKt {
+	public static final fun resetConsentHandler (Landroidx/compose/runtime/Composer;I)Lkotlin/jvm/functions/Function0;
+	public static final fun resetOnboardingHandler (Landroidx/compose/runtime/Composer;I)Lkotlin/jvm/functions/Function0;
 }
 

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/privacy/PrivacyNavigation.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/privacy/PrivacyNavigation.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.screen.ui.privacy
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavGraphBuilder
+import dev.teogor.ceres.navigation.core.ScreenRoute
+import dev.teogor.ceres.navigation.core.screenNav
+
+private const val navPath = "privacy_options_path"
+
+object PrivacyOptionsRoute : ScreenRoute {
+  override val route: String = navPath
+}
+
+inline fun NavGraphBuilder.privacyOptionsNavPath(
+  crossinline block: @Composable () -> Unit,
+) = screenNav(
+  route = PrivacyOptionsRoute.route,
+) {
+  block()
+}

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/privacy/PrivacyScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/privacy/PrivacyScreen.kt
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.screen.ui.privacy
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.MonetizationOn
+import androidx.compose.material.icons.filled.Person2
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.teogor.ceres.core.foundation.ui.platform.LocalApplicationDetails
+import dev.teogor.ceres.data.datastore.common.UserID
+import dev.teogor.ceres.data.datastore.common.getPrivacyFormattedValue
+import dev.teogor.ceres.data.datastore.defaults.ceresPreferences
+import dev.teogor.ceres.screen.builder.compose.HeaderView
+import dev.teogor.ceres.screen.builder.compose.SimpleView
+import dev.teogor.ceres.screen.core.scope.ScreenListScope
+import dev.teogor.ceres.screen.ui.utils.resetConsentHandler
+import dev.teogor.ceres.screen.ui.utils.resetOnboardingHandler
+import dev.teogor.ceres.ui.designsystem.AlertDialog
+import dev.teogor.ceres.ui.designsystem.Button
+import dev.teogor.ceres.ui.designsystem.CeresButtonDefaults
+import dev.teogor.ceres.ui.designsystem.CheckboxWithText
+import dev.teogor.ceres.ui.designsystem.OutlinedButton
+import dev.teogor.ceres.ui.designsystem.Text
+import dev.teogor.ceres.ui.theme.MaterialTheme
+import dev.teogor.ceres.ui.theme.toColor
+import dev.teogor.ceres.ui.theme.tokens.ColorSchemeKeyTokens
+
+fun ScreenListScope.privacyOptionsHeader() = item {
+  HeaderView(
+    title = "Privacy Options",
+  )
+}
+
+fun ScreenListScope.resetAdsConsentOption() = item {
+  var dialogVisible by remember { mutableStateOf(false) }
+  val resetConsentHandler = resetConsentHandler()
+  SimpleView(
+    title = "Reset Ads Consent",
+    subtitle = "Reset your preferences for personalized ads",
+    icon = Icons.Default.Refresh,
+    clickable = {
+      dialogVisible = true
+    },
+  )
+
+  if (dialogVisible) {
+    AlertDialog(
+      onDismissRequest = { dialogVisible = false },
+      title = {
+        Text("Reset Ads Consent")
+      },
+      text = {
+        Column {
+          Text("Are you sure you want to reset your personalized ads preferences?")
+        }
+      },
+      confirmButton = {
+        Button(
+          onClick = {
+            resetConsentHandler()
+            dialogVisible = false
+          },
+        ) {
+          Text("Reset")
+        }
+      },
+      dismissButton = {
+        OutlinedButton(
+          onClick = {
+            dialogVisible = false
+          },
+          border = BorderStroke(
+            width = CeresButtonDefaults.OutlinedButtonBorderWidth,
+            color = ColorSchemeKeyTokens.Primary.toColor(),
+          ),
+        ) {
+          Text(
+            text = "Cancel",
+            color = ColorSchemeKeyTokens.Primary.toColor(),
+          )
+        }
+      },
+    )
+  }
+}
+
+fun ScreenListScope.privacyUserId() = item {
+  var showFullUserId by remember { mutableStateOf(false) }
+  // todo auto-flow
+  val userId = remember(ceresPreferences().userId) {
+    ceresPreferences().userId
+  }
+  val formattedUserId by remember(showFullUserId) {
+    mutableStateOf(if (showFullUserId) userId.value else userId.getPrivacyFormattedValue(6))
+  }
+
+  val clipboardManager = LocalClipboardManager.current
+  SimpleView(
+    title = "User ID",
+    subtitle = formattedUserId,
+    icon = Icons.Default.Person2,
+    clickable = {
+      clipboardManager.setText(
+        buildAnnotatedString {
+          append(userId.value)
+        },
+      )
+      // toast("User ID copied to clipboard!")
+    },
+    content = {
+      Column(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 20.dp),
+      ) {
+        Row(
+          modifier = Modifier.align(Alignment.End),
+        ) {
+          OutlinedButton(
+            modifier = Modifier
+              .defaultMinSize(
+                minWidth = 20.dp,
+                minHeight = 10.dp,
+              ),
+            onClick = {
+              showFullUserId = !showFullUserId
+            },
+          ) {
+            Text(
+              text = if (showFullUserId) "Show Less" else "Show More",
+              modifier = Modifier.padding(horizontal = 2.dp),
+            )
+          }
+
+          Spacer(modifier = Modifier.width(8.dp))
+
+          Button(
+            modifier = Modifier
+              .defaultMinSize(
+                minWidth = 20.dp,
+                minHeight = 10.dp,
+              ),
+            onClick = {
+              ceresPreferences().userId = UserID().apply {
+                generate()
+              }
+            },
+          ) {
+            Text(
+              text = "Reset",
+              modifier = Modifier.padding(horizontal = 2.dp),
+            )
+          }
+        }
+      }
+    },
+  )
+}
+
+fun ScreenListScope.privacyResetOnboarding() = item {
+  var dialogVisible by remember { mutableStateOf(false) }
+  var deleteContentChecked by remember { mutableStateOf(false) }
+  val resetOnboardingHandler = resetOnboardingHandler()
+  SimpleView(
+    title = "Reset Onboarding",
+    subtitle = "Start the onboarding process again",
+    icon = Icons.Default.Refresh,
+    clickable = {
+      dialogVisible = true
+    },
+  )
+
+  if (dialogVisible) {
+    AlertDialog(
+      onDismissRequest = { dialogVisible = false },
+      title = {
+        Text("Restart Onboarding Process")
+      },
+      text = {
+        Column {
+          Text("Are you sure you want to clear all onboarding progress and start over?")
+          Spacer(modifier = Modifier.height(8.dp))
+          CheckboxWithText(
+            text = "Delete user-stored content",
+            isChecked = deleteContentChecked,
+            onCheckedChange = { isChecked ->
+              deleteContentChecked = isChecked
+            },
+          )
+          if (deleteContentChecked) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+              text = "This action cannot be undone.",
+              color = MaterialTheme.colorScheme.error,
+              fontSize = 12.sp,
+            )
+          }
+        }
+      },
+      confirmButton = {
+        Button(
+          onClick = {
+            if (deleteContentChecked) {
+              val ceresPreferences = ceresPreferences()
+              ceresPreferences.name = ""
+              ceresPreferences.coverImage = ""
+              ceresPreferences.profileImage = ""
+            }
+            resetOnboardingHandler()
+            dialogVisible = false
+          },
+        ) {
+          Text("Restart")
+        }
+      },
+      dismissButton = {
+        OutlinedButton(
+          onClick = {
+            dialogVisible = false
+          },
+          border = BorderStroke(
+            width = CeresButtonDefaults.OutlinedButtonBorderWidth,
+            color = ColorSchemeKeyTokens.Primary.toColor(),
+          ),
+        ) {
+          Text(
+            text = "Cancel",
+            color = ColorSchemeKeyTokens.Primary.toColor(),
+          )
+        }
+      },
+    )
+  }
+}
+
+fun ScreenListScope.legalAgreementsHeader() = item {
+  HeaderView(
+    title = "Legal Agreements",
+  )
+}
+
+fun ScreenListScope.privacyPolicyOption() = item {
+  val uriHandler = LocalUriHandler.current
+  val applicationDetails = LocalApplicationDetails.current
+  SimpleView(
+    title = "Privacy Policy",
+    subtitle = "Review our Privacy Policy",
+    icon = Icons.Default.Link,
+    clickable = {
+      applicationDetails.privacyLink?.let {
+        uriHandler.openUri(it)
+      }
+    },
+  )
+}
+
+fun ScreenListScope.termsOfServiceOption() = item {
+  val uriHandler = LocalUriHandler.current
+  val applicationDetails = LocalApplicationDetails.current
+  SimpleView(
+    title = "Terms of Service",
+    subtitle = "Review our Terms of Service",
+    icon = Icons.Default.Link,
+    clickable = {
+      applicationDetails.privacyLink?.let {
+        uriHandler.openUri(it)
+      }
+    },
+  )
+}
+
+fun ScreenListScope.policyCopyrightPolicy() = item {
+  SimpleView(
+    title = "Copyright Policy",
+    subtitle = "Review our Copyright Policy",
+    icon = Icons.Filled.Description,
+    clickable = {
+    },
+  )
+}
+
+fun ScreenListScope.policyRefundPolicy() = item {
+  SimpleView(
+    title = "Refund Policy",
+    subtitle = "Review our Refund Policy",
+    icon = Icons.Filled.MonetizationOn,
+    clickable = {
+    },
+  )
+}
+
+fun ScreenListScope.policyAppLicensePolicy() = item {
+  SimpleView(
+    title = "App License",
+    subtitle = "Licensed under Apache License 2.0",
+    icon = Icons.Filled.Code,
+  )
+}

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/settings/SettingsComponents.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/settings/SettingsComponents.kt
@@ -17,6 +17,7 @@
 package dev.teogor.ceres.screen.ui.settings
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PrivacyTip
 import androidx.compose.material.icons.filled.SettingsBackupRestore
 import androidx.compose.material.icons.filled.Style
 import dev.teogor.ceres.navigation.core.LocalNavigationParameters
@@ -24,6 +25,7 @@ import dev.teogor.ceres.screen.builder.compose.HeaderView
 import dev.teogor.ceres.screen.builder.compose.SimpleView
 import dev.teogor.ceres.screen.core.scope.ScreenListScope
 import dev.teogor.ceres.screen.ui.lookandfeel.LookAndFeelScreenRoute
+import dev.teogor.ceres.screen.ui.privacy.PrivacyOptionsRoute
 
 fun ScreenListScope.settingsHeaderUI() = item {
   HeaderView(
@@ -57,5 +59,23 @@ fun ScreenListScope.settingsBackup() = item {
 fun ScreenListScope.settingsHeaderSystem() = item {
   HeaderView(
     title = "System",
+  )
+}
+
+fun ScreenListScope.settingsHeaderDataPrivacy() = item {
+  HeaderView(
+    title = "Data & Privacy",
+  )
+}
+
+fun ScreenListScope.settingsPrivacyOptions() = item {
+  val navigation = LocalNavigationParameters.current
+  SimpleView(
+    title = "Privacy Options",
+    subtitle = "Manage your data and privacy preferences",
+    icon = Icons.Default.PrivacyTip,
+    clickable = {
+      navigation.screenRoute = PrivacyOptionsRoute
+    },
   )
 }

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/utils/Invokers.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/utils/Invokers.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.screen.ui.utils
+
+import androidx.compose.runtime.Composable
+import dev.teogor.ceres.data.datastore.defaults.ceresPreferences
+import dev.teogor.ceres.monetisation.ads.ExperimentalAdsControlApi
+import dev.teogor.ceres.monetisation.ads.LocalAdsControl
+import dev.teogor.ceres.navigation.core.LocalNavigationParameters
+import dev.teogor.ceres.screen.ui.api.ExperimentalOnboardingScreenApi
+import dev.teogor.ceres.screen.ui.onboarding.OnboardingRoute
+
+@OptIn(ExperimentalAdsControlApi::class)
+@Composable
+fun resetConsentHandler(): () -> Unit {
+  val adsControl = LocalAdsControl.current
+  val resetOnboarding: () -> Unit = {
+    adsControl.resetConsent()
+  }
+
+  return resetOnboarding
+}
+
+@OptIn(ExperimentalOnboardingScreenApi::class, ExperimentalAdsControlApi::class)
+@Composable
+fun resetOnboardingHandler(): () -> Unit {
+  val navigationParameters = LocalNavigationParameters.current
+  val adsControl = LocalAdsControl.current
+
+  val resetOnboarding: () -> Unit = {
+    val ceresPreferences = ceresPreferences()
+    ceresPreferences.onboardingComplete = false
+    adsControl.resetConsent()
+    navigationParameters.screenRoute = OnboardingRoute
+  }
+
+  return resetOnboarding
+}


### PR DESCRIPTION
This pull request introduces several new classes and functions related to privacy settings and navigation in the Ceres app. Here's a summary of the changes:

1. **Privacy Navigation:** Added `PrivacyNavigationKt`, which contains a function `privacyOptionsNavPath` for defining the navigation path to the privacy options screen.

2. **Privacy Options Route:** Created `PrivacyOptionsRoute`, a class that implements the `ScreenRoute` interface to define the route for the privacy options screen.

3. **Privacy Screen Functions:** In `PrivacyScreenKt`, added various functions for composing different sections of the privacy screen, such as legal agreements, policy details, and consent options.