### PR TITLE
Move `UserID` class to `core.foundation.models`

### DIFF
--- a/core/foundation/api/foundation.api
+++ b/core/foundation/api/foundation.api
@@ -279,6 +279,29 @@ public final class dev/teogor/ceres/core/foundation/extensions/MediaPlayerExtKt 
 	public static final fun createMediaPlayer (Landroid/net/Uri;Landroid/view/SurfaceHolder;Landroid/media/AudioAttributes;ILandroidx/compose/runtime/Composer;II)Landroid/media/MediaPlayer;
 }
 
+public final class dev/teogor/ceres/core/foundation/models/UserID {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/teogor/ceres/core/foundation/models/UserID;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/core/foundation/models/UserID;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/ceres/core/foundation/models/UserID;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun generate ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isEmpty ()Z
+	public final fun setValue (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/ceres/core/foundation/models/UserIDKt {
+	public static final fun getFormattedValueInRows (Ldev/teogor/ceres/core/foundation/models/UserID;)Ljava/lang/String;
+	public static final fun getPrivacyFormattedValue (Ldev/teogor/ceres/core/foundation/models/UserID;I)Ljava/lang/String;
+	public static synthetic fun getPrivacyFormattedValue$default (Ldev/teogor/ceres/core/foundation/models/UserID;IILjava/lang/Object;)Ljava/lang/String;
+}
+
 public abstract interface class dev/teogor/ceres/core/foundation/ui/platform/ApplicationDetails {
 	public abstract fun getAppName ()Ljava/lang/String;
 	public abstract fun getPrivacyEmail ()Ljava/lang/String;

--- a/core/foundation/src/main/kotlin/dev/teogor/ceres/core/foundation/models/UserID.kt
+++ b/core/foundation/src/main/kotlin/dev/teogor/ceres/core/foundation/models/UserID.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dev.teogor.ceres.data.datastore.common
+package dev.teogor.ceres.core.foundation.models
 
 import java.util.UUID
 import java.util.regex.Pattern

--- a/data/database/build.gradle.kts
+++ b/data/database/build.gradle.kts
@@ -16,6 +16,8 @@
 plugins {
   id("dev.teogor.ceres.android.library")
   id("dev.teogor.ceres.android.library.jacoco")
+  id("dev.teogor.ceres.android.hilt")
+  id("dev.teogor.ceres.android.room")
 }
 
 android {

--- a/data/datastore/api/datastore.api
+++ b/data/datastore/api/datastore.api
@@ -29,28 +29,6 @@ public final class dev/teogor/ceres/data/datastore/common/PreferenceDatastoreKt 
 	public static final fun launch (Ldev/teogor/ceres/data/datastore/common/PreferenceDatastore;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/Job;
 }
 
-public final class dev/teogor/ceres/data/datastore/common/UserID {
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Ldev/teogor/ceres/data/datastore/common/UserID;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/data/datastore/common/UserID;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/ceres/data/datastore/common/UserID;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun generate ()Ljava/lang/String;
-	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public final fun isEmpty ()Z
-	public final fun setValue (Ljava/lang/String;)V
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class dev/teogor/ceres/data/datastore/common/UserIDKt {
-	public static final fun getFormattedValueInRows (Ldev/teogor/ceres/data/datastore/common/UserID;)Ljava/lang/String;
-	public static final fun getPrivacyFormattedValue (Ldev/teogor/ceres/data/datastore/common/UserID;I)Ljava/lang/String;
-	public static synthetic fun getPrivacyFormattedValue$default (Ldev/teogor/ceres/data/datastore/common/UserID;IILjava/lang/Object;)Ljava/lang/String;
-}
-
 public final class dev/teogor/ceres/data/datastore/defaults/AppTheme : java/lang/Enum {
 	public static final field ClearlyWhite Ldev/teogor/ceres/data/datastore/defaults/AppTheme;
 	public static final field FollowSystem Ldev/teogor/ceres/data/datastore/defaults/AppTheme;
@@ -87,7 +65,7 @@ public final class dev/teogor/ceres/data/datastore/defaults/CeresPreferences : d
 	public final fun getProfileImageFlow ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getThemeSeed ()Ljava/lang/String;
 	public final fun getThemeSeedFlow ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getUserId ()Ldev/teogor/ceres/data/datastore/common/UserID;
+	public final fun getUserId ()Ldev/teogor/ceres/core/foundation/models/UserID;
 	public final fun setAppTheme (Ldev/teogor/ceres/data/datastore/defaults/AppTheme;)V
 	public final fun setCoverImage (Ljava/lang/String;)V
 	public final fun setDisableAndroidTheme (Z)V
@@ -100,7 +78,7 @@ public final class dev/teogor/ceres/data/datastore/defaults/CeresPreferences : d
 	public final fun setOnboardingComplete (Z)V
 	public final fun setProfileImage (Ljava/lang/String;)V
 	public final fun setThemeSeed (Ljava/lang/String;)V
-	public final fun setUserId (Ldev/teogor/ceres/data/datastore/common/UserID;)V
+	public final fun setUserId (Ldev/teogor/ceres/core/foundation/models/UserID;)V
 }
 
 public final class dev/teogor/ceres/data/datastore/defaults/CeresPreferencesKt {

--- a/data/datastore/build.gradle.kts
+++ b/data/datastore/build.gradle.kts
@@ -50,6 +50,7 @@ protobuf {
 
 dependencies {
   api(project(":core:startup"))
+  api(project(":core:foundation"))
 
   api(libs.androidx.dataStore.preferences)
   api(libs.androidx.dataStore.core)

--- a/data/datastore/src/main/kotlin/dev/teogor/ceres/data/datastore/defaults/CeresPreferences.kt
+++ b/data/datastore/src/main/kotlin/dev/teogor/ceres/data/datastore/defaults/CeresPreferences.kt
@@ -23,10 +23,10 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.google.gson.reflect.TypeToken
+import dev.teogor.ceres.core.foundation.models.UserID
 import dev.teogor.ceres.core.startup.ApplicationContextProvider
 import dev.teogor.ceres.data.datastore.common.DataStoreManager
 import dev.teogor.ceres.data.datastore.common.PreferenceDatastore
-import dev.teogor.ceres.data.datastore.common.UserID
 import dev.teogor.ceres.data.datastore.defaults.AppTheme.FollowSystem
 import dev.teogor.ceres.data.datastore.defaults.JustBlackTheme.Off
 import kotlinx.coroutines.flow.firstOrNull

--- a/framework/core/src/main/kotlin/dev/teogor/ceres/framework/core/menu/MenuUtils.kt
+++ b/framework/core/src/main/kotlin/dev/teogor/ceres/framework/core/menu/MenuUtils.kt
@@ -34,8 +34,8 @@ import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.components.rememberImageComponent
 import com.skydoves.landscapist.glide.GlideImage
 import com.skydoves.landscapist.placeholder.thumbnail.ThumbnailPlugin
+import dev.teogor.ceres.core.foundation.models.getPrivacyFormattedValue
 import dev.teogor.ceres.data.compose.rememberPreference
-import dev.teogor.ceres.data.datastore.common.getPrivacyFormattedValue
 import dev.teogor.ceres.data.datastore.defaults.ceresPreferences
 import dev.teogor.ceres.ui.designsystem.Text
 import dev.teogor.ceres.ui.theme.MaterialTheme

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/privacy/PrivacyScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/privacy/PrivacyScreen.kt
@@ -43,9 +43,9 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.teogor.ceres.core.foundation.models.UserID
+import dev.teogor.ceres.core.foundation.models.getPrivacyFormattedValue
 import dev.teogor.ceres.core.foundation.ui.platform.LocalApplicationDetails
-import dev.teogor.ceres.data.datastore.common.UserID
-import dev.teogor.ceres.data.datastore.common.getPrivacyFormattedValue
 import dev.teogor.ceres.data.datastore.defaults.ceresPreferences
 import dev.teogor.ceres.screen.builder.compose.HeaderView
 import dev.teogor.ceres.screen.builder.compose.SimpleView


### PR DESCRIPTION
This PR relocates the `UserID` class from its previous location in the `data.datastore.common` package to the new destination in the `core.foundation.models` package. This move is part of our ongoing efforts to restructure and organize our codebase for improved maintainability and organization.

No functional changes have been made to the `UserID` class itself; it has merely been moved to a more appropriate package. This change ensures that our codebase adheres to a cleaner and more logical structure, making it easier for developers to find and manage relevant classes and models.