### PR TITLE
Update AdMob SDK Initialization Based on Consent Status

### DIFF
--- a/monetisation/admob/api/admob.api
+++ b/monetisation/admob/api/admob.api
@@ -59,6 +59,7 @@ public abstract class dev/teogor/ceres/monetisation/admob/formats/Ad : dev/teogo
 	public fun <init> ()V
 	public fun <init> (Z)V
 	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun canRequestAds ()Z
 	public final fun canShow ()Z
 	public final fun getAdEvent ()Landroidx/compose/runtime/MutableState;
 	public fun getConcurrentAdLoadLimit ()I
@@ -66,7 +67,7 @@ public abstract class dev/teogor/ceres/monetisation/admob/formats/Ad : dev/teogo
 	public fun getTag ()Ljava/lang/String;
 	public final fun isAdLoaded ()Z
 	protected final fun isLoading ()Z
-	public final fun isNetworkAvailable ()Z
+	public fun isNetworkAvailable ()Z
 	public final fun isReady ()Z
 	protected final fun isShowing ()Z
 	public fun load ()Z

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/Ad.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/Ad.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.mutableStateOf
 import dev.teogor.ceres.core.foundation.FoundationGlobal
 import dev.teogor.ceres.core.startup.ApplicationContextProvider
 import dev.teogor.ceres.monetisation.admob.Logger
+import dev.teogor.ceres.monetisation.ads.AdsControlProvider
 
 abstract class Ad(
   loadAtInitialisation: Boolean = false,
@@ -31,7 +32,13 @@ abstract class Ad(
 
   abstract fun useCache(): Boolean
 
-  fun isNetworkAvailable() = !FoundationGlobal.networkMonitor.isOffline
+  open fun isNetworkAvailable(): Boolean {
+    return !FoundationGlobal.networkMonitor.isOffline
+  }
+
+  open fun canRequestAds(): Boolean {
+    return AdsControlProvider.canRequestAds()
+  }
 
   protected var isLoading = false
   protected var isShowing = false
@@ -131,7 +138,7 @@ abstract class Ad(
     adEvent.value = event
   }
 
-  fun canShow() = isNetworkAvailable()
+  fun canShow() = isNetworkAvailable() && canRequestAds()
 
   fun isAdLoaded() = adEvent.value == AdEvent.AdLoaded
 

--- a/monetisation/ads/api/ads.api
+++ b/monetisation/ads/api/ads.api
@@ -17,6 +17,7 @@ public final class dev/teogor/ceres/monetisation/ads/AdsControlProvider {
 	public static final field $stable I
 	public static final field INSTANCE Ldev/teogor/ceres/monetisation/ads/AdsControlProvider;
 	public static field adsControl Ldev/teogor/ceres/monetisation/ads/AdsControl;
+	public final fun canRequestAds ()Z
 	public final fun getAdsControl ()Ldev/teogor/ceres/monetisation/ads/AdsControl;
 	public final fun initialize (Ldev/teogor/ceres/monetisation/ads/AdsControl;)V
 	public final fun setAdsControl (Ldev/teogor/ceres/monetisation/ads/AdsControl;)V

--- a/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/AdsControlProvider.kt
+++ b/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/AdsControlProvider.kt
@@ -25,4 +25,11 @@ object AdsControlProvider {
   fun initialize(adsControl: AdsControl) {
     this.adsControl = adsControl
   }
+
+  fun canRequestAds(): Boolean {
+    if (!::adsControl.isInitialized) {
+      return false
+    }
+    return adsControl.canRequestAds.value
+  }
 }

--- a/monetisation/messaging/src/main/kotlin/dev/teogor/ceres/monetisation/messaging/ConsentManager.kt
+++ b/monetisation/messaging/src/main/kotlin/dev/teogor/ceres/monetisation/messaging/ConsentManager.kt
@@ -26,6 +26,7 @@ import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
 import com.google.android.ump.UserMessagingPlatform
 import dev.teogor.ceres.core.runtime.AppMetadataManager
+import dev.teogor.ceres.monetisation.admob.AdMob
 import dev.teogor.ceres.monetisation.admob.AdMobInitializer
 import dev.teogor.ceres.monetisation.admob.AdMobInitializer.getHashedAdvertisingId
 import dev.teogor.ceres.monetisation.ads.AdsControl
@@ -146,6 +147,8 @@ object ConsentManager {
     adsControl.canRequestAds.value = consentInformation.canRequestAds()
     if (consentInformation.canRequestAds()) {
       initializeMobileAdsSdk(activity)
+
+      attemptToReloadAppOpenAd()
     }
   }
 
@@ -162,6 +165,7 @@ object ConsentManager {
       // Consent has been gathered or not required
       if (consentInformation.canRequestAds()) {
         initializeMobileAdsSdk(activity)
+        attemptToReloadAppOpenAd()
       }
 
       state.value = ConsentResult.ConsentFormAcquired(
@@ -187,5 +191,13 @@ object ConsentManager {
 
     // Initialize the Google Mobile Ads SDK.
     AdMobInitializer.initialize(context)
+  }
+
+  private fun attemptToReloadAppOpenAd() {
+    AdMob.getAppOpenAd()?.let { appOpenAd ->
+      if (!appOpenAd.isAdLoaded()) {
+        appOpenAd.load()
+      }
+    }
   }
 }


### PR DESCRIPTION
This pull request addresses the issue of initializing the AdMob SDK based on the user's consent status. Previously, the SDK was initialized without considering the consent status, leading to ads being loaded even when the user had not provided consent.

**Changes Made:**

- Updated the `ConsentManager` to handle the consent status.
- Initialized the AdMob SDK only when the user has given consent to request ads.
- Added a check to reload the App Open Ad if it was not loaded.

These changes ensure that the AdMob SDK is initialized appropriately, respecting the user's consent preferences.


**Related Issue:**
closes #141 