### PR TITLE
Add Lifecycle Observation Utilities for Activity, Application, and Composable Components

### DIFF
--- a/core/common/api/common.api
+++ b/core/common/api/common.api
@@ -8,6 +8,9 @@ public final class dev/teogor/ceres/core/common/utils/ContextUtilsKt {
 }
 
 public final class dev/teogor/ceres/core/common/utils/LifecycleUtilsKt {
+	public static final fun ObserveActivityLifecycle (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ObserveApplicationLifecycle (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ObserveComposableLifecycle (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
 	public static final fun OnLifecycleEvent (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
 }
 

--- a/core/common/api/common.api
+++ b/core/common/api/common.api
@@ -7,3 +7,7 @@ public final class dev/teogor/ceres/core/common/utils/ContextUtilsKt {
 	public static final fun getActivity (Landroidx/compose/runtime/Composer;I)Landroid/app/Activity;
 }
 
+public final class dev/teogor/ceres/core/common/utils/LifecycleUtilsKt {
+	public static final fun OnLifecycleEvent (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+}
+

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -28,6 +28,7 @@ android {
 
 dependencies {
   api(libs.androidx.annotation)
+  api(libs.androidx.lifecycle.common)
   api(libs.androidx.compose.runtime)
   api(libs.androidx.compose.ui.tooling)
 }

--- a/core/common/src/main/kotlin/dev/teogor/ceres/core/common/utils/LifecycleUtils.kt
+++ b/core/common/src/main/kotlin/dev/teogor/ceres/core/common/utils/LifecycleUtils.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.core.common.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+
+/**
+ * Composable function to observe the lifecycle events of the current LifecycleOwner
+ * and execute the provided [onEvent] lambda when a lifecycle event occurs.
+ *
+ * @param onEvent Lambda function to handle lifecycle events with parameters [owner]
+ *                and [event], where [owner] is the LifecycleOwner and [event] is
+ *                the Lifecycle.Event.
+ */
+@Composable
+fun OnLifecycleEvent(onEvent: (owner: LifecycleOwner, event: Lifecycle.Event) -> Unit) {
+  val eventHandler = rememberUpdatedState(onEvent)
+  val lifecycleOwner = rememberUpdatedState(LocalLifecycleOwner.current)
+
+  DisposableEffect(lifecycleOwner.value) {
+    val lifecycle = lifecycleOwner.value.lifecycle
+    val observer = LifecycleEventObserver { owner, event ->
+      eventHandler.value(owner, event)
+    }
+
+    lifecycle.addObserver(observer)
+    onDispose {
+      lifecycle.removeObserver(observer)
+    }
+  }
+}

--- a/core/common/src/main/kotlin/dev/teogor/ceres/core/common/utils/LifecycleUtils.kt
+++ b/core/common/src/main/kotlin/dev/teogor/ceres/core/common/utils/LifecycleUtils.kt
@@ -16,10 +16,15 @@
 
 package dev.teogor.ceres.core.common.utils
 
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
@@ -46,6 +51,133 @@ fun OnLifecycleEvent(onEvent: (owner: LifecycleOwner, event: Lifecycle.Event) ->
     lifecycle.addObserver(observer)
     onDispose {
       lifecycle.removeObserver(observer)
+    }
+  }
+}
+
+/**
+ * Observe the lifecycle of the current Activity. This can be useful for performing actions when
+ * the Activity enters or exits the foreground.
+ *
+ * @param onEnterForeground Callback to execute when the Activity enters the foreground.
+ * @param onExitForeground Callback to execute when the Activity exits the foreground.
+ */
+@Composable
+fun ObserveActivityLifecycle(
+  onEnterForeground: () -> Unit = {},
+  onExitForeground: () -> Unit = {}
+) {
+  val currentActivity = activity
+
+  currentActivity?.let {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(currentActivity) {
+      val lifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onStop(owner: LifecycleOwner) {
+          super.onStop(owner)
+          onExitForeground()
+        }
+
+        override fun onStart(owner: LifecycleOwner) {
+          super.onStart(owner)
+          onEnterForeground()
+        }
+      }
+
+      val lifecycle = lifecycleOwner.lifecycle
+      lifecycle.addObserver(lifecycleObserver)
+
+      onDispose {
+        lifecycle.removeObserver(lifecycleObserver)
+      }
+    }
+  }
+}
+
+/**
+ * Observe the lifecycle of the Application. This can be useful for performing actions when
+ * the Application enters or exits the foreground.
+ *
+ * @param onEnterForeground Callback to execute when the Application enters the foreground.
+ * @param onExitForeground Callback to execute when the Application exits the foreground.
+ */
+@Composable
+fun ObserveApplicationLifecycle(
+  onEnterForeground: () -> Unit = {},
+  onExitForeground: () -> Unit = {}
+) {
+  val context = LocalContext.current.applicationContext as Application
+
+  DisposableEffect(context) {
+    val observer = object : Application.ActivityLifecycleCallbacks {
+      override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        // Unused
+      }
+
+      override fun onActivityStarted(activity: Activity) {
+        // Unused
+      }
+
+      override fun onActivityResumed(activity: Activity) {
+        onEnterForeground()
+      }
+
+      override fun onActivityPaused(activity: Activity) {
+        onExitForeground()
+      }
+
+      override fun onActivityStopped(activity: Activity) {
+        // Unused
+      }
+
+      override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+        // Unused
+      }
+
+      override fun onActivityDestroyed(activity: Activity) {
+        // Unused
+      }
+    }
+
+    context.registerActivityLifecycleCallbacks(observer)
+
+    onDispose {
+      context.unregisterActivityLifecycleCallbacks(observer)
+    }
+  }
+}
+
+/**
+ * Observe the lifecycle of the current Composable. This can be useful for performing actions when
+ * the Composable enters or exits the foreground.
+ *
+ * @param onEnterForeground Callback to execute when the Composable enters the foreground.
+ * @param onExitForeground Callback to execute when the Composable exits the foreground.
+ */
+@Composable
+fun ObserveComposableLifecycle(
+  onEnterForeground: () -> Unit = {},
+  onExitForeground: () -> Unit = {}
+) {
+  val lifecycleOwner = LocalLifecycleOwner.current
+
+  DisposableEffect(Unit) {
+    val lifecycleObserver = object : DefaultLifecycleObserver {
+      override fun onStop(owner: LifecycleOwner) {
+        super.onStop(owner)
+        onExitForeground()
+      }
+
+      override fun onStart(owner: LifecycleOwner) {
+        super.onStart(owner)
+        onEnterForeground()
+      }
+    }
+
+    lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
+
+    onDispose {
+      lifecycleOwner.lifecycle.removeObserver(lifecycleObserver)
     }
   }
 }

--- a/framework/core/build.gradle.kts
+++ b/framework/core/build.gradle.kts
@@ -29,6 +29,7 @@ android {
 }
 
 dependencies {
+  api(project(":core:common"))
   api(project(":core:foundation"))
   api(project(":core:network"))
   api(project(":core:runtime"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,6 +102,7 @@ androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscree
 androidx-dataStore-core = { group = "androidx.datastore", name = "datastore", version.ref = "androidxDataStore" }
 androidx-dataStore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDataStore" }
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "androidxHiltNavigationCompose" }
+androidx-lifecycle-common = { group = "androidx.lifecycle", name = "lifecycle-common", version.ref = "androidxLifecycle" }
 androidx-lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtimeCompose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }


### PR DESCRIPTION
This PR introduces a set of utility functions to observe the lifecycles of Activity, Application, and Composable components in a Jetpack Compose application. These utilities enable developers to execute custom actions when these components enter or exit the foreground.

The following functions have been added:
1. `ObserveActivityLifecycle`: Observes the lifecycle of the current Activity, allowing actions to be performed when it enters or exits the foreground.

2. `ObserveApplicationLifecycle`: Observes the lifecycle of the Application, enabling actions to be taken when it enters or exits the foreground.

3. `ObserveComposableLifecycle`: Observes the lifecycle of the current Composable, allowing actions to be performed when it enters or exits the foreground.

Additionally, a generic `OnLifecycleEvent` composable function has been introduced for observing the lifecycle of any `LifecycleOwner` and executing custom actions upon lifecycle events.

These utilities provide a convenient way to manage lifecycle-related behavior in Jetpack Compose applications.