### PR TITLE
Upgrade Hilt Plugin to Use KSP Instead of Kapt

### DIFF
--- a/plugin/library-convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
+++ b/plugin/library-convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
@@ -24,17 +24,15 @@ class AndroidHiltConventionPlugin : Plugin<Project> {
   override fun apply(target: Project) {
     with(target) {
       with(pluginManager) {
+        apply("com.google.devtools.ksp")
         apply("dagger.hilt.android.plugin")
-        // KAPT must go last to avoid build warnings.
-        // See: https://stackoverflow.com/questions/70550883/warning-the-following-options-were-not-recognized-by-any-processor-dagger-f
-        apply("org.jetbrains.kotlin.kapt")
       }
 
       val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
       dependencies {
         "implementation"(libs.findLibrary("hilt.android").get())
-        "kapt"(libs.findLibrary("hilt.compiler").get())
-        "kaptAndroidTest"(libs.findLibrary("hilt.compiler").get())
+        "ksp"(libs.findLibrary("hilt.compiler").get())
+        "kspAndroidTest"(libs.findLibrary("hilt.compiler").get())
       }
     }
   }


### PR DESCRIPTION
### Description

This PR includes an upgrade to the Hilt plugin configuration, enabling it to utilize the Kotlin Symbol Processor (KSP) for code generation instead of Kotlin Annotation Processor (Kapt). This change is aimed at enhancing compatibility with the Hilt library and improving the build process.

### Changes Made

- Reconfigured the Hilt plugin to apply the Kotlin Symbol Processor (KSP).
- Removed the application of Kapt to eliminate build warnings and streamline the build process.