### PR TITLE
Enhance Room Plugin with Schema Export Support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,11 +22,16 @@ plugins {
   id("dev.teogor.ceres.android.application.jacoco")
   id("dev.teogor.ceres.android.application.firebase")
   id("dev.teogor.ceres.android.hilt")
+  id("dev.teogor.ceres.android.room")
   id("kotlinx-serialization")
   id("jacoco")
 
   // Feature :: About
   alias(libs.plugins.about.libraries) apply true
+}
+
+roomOptions {
+  enableSchemaProvider = true
 }
 
 android {

--- a/plugin/library-convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
+++ b/plugin/library-convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
@@ -15,6 +15,7 @@
  */
 
 import com.google.devtools.ksp.gradle.KspExtension
+import dev.teogor.ceres.models.RoomOptionsExtension
 import java.io.File
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -23,6 +24,7 @@ import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.process.CommandLineArgumentProvider
@@ -30,14 +32,22 @@ import org.gradle.process.CommandLineArgumentProvider
 class AndroidRoomConventionPlugin : Plugin<Project> {
 
   override fun apply(target: Project) {
+    val roomOptions = target.extensions.create<RoomOptionsExtension>(
+      name = "roomOptions",
+    )
+
     with(target) {
       pluginManager.apply("com.google.devtools.ksp")
 
-      extensions.configure<KspExtension> {
-        // The schemas directory contains a schema file for each version of the Room database.
-        // This is required to enable Room auto migrations.
-        // See https://developer.android.com/reference/kotlin/androidx/room/AutoMigration.
-        arg(RoomSchemaArgProvider(File(projectDir, "schemas")))
+      afterEvaluate {
+        extensions.configure<KspExtension> {
+          // The schemas directory contains a schema file for each version of the Room database.
+          // This is required to enable Room auto migrations.
+          // See https://developer.android.com/reference/kotlin/androidx/room/AutoMigration.
+          if(roomOptions.enableSchemaProvider) {
+            arg(RoomSchemaArgProvider(File(projectDir, roomOptions.schemasPath)))
+          }
+        }
       }
 
       val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
@@ -58,6 +68,17 @@ class AndroidRoomConventionPlugin : Plugin<Project> {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     val schemaDir: File,
   ) : CommandLineArgumentProvider {
+    init {
+      if (!schemaDir.exists()) {
+        val created = schemaDir.mkdirs()
+        if (created) {
+          println("Created directory: ${schemaDir.absolutePath}")
+        } else {
+          println("Failed to create directory: ${schemaDir.absolutePath}")
+        }
+      }
+    }
+
     override fun asArguments() = listOf("room.schemaLocation=${schemaDir.path}")
   }
 }

--- a/plugin/library-convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
+++ b/plugin/library-convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
+import com.google.devtools.ksp.gradle.KspExtension
+import java.io.File
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.process.CommandLineArgumentProvider
-import java.io.File
 
 class AndroidRoomConventionPlugin : Plugin<Project> {
 
@@ -31,12 +33,12 @@ class AndroidRoomConventionPlugin : Plugin<Project> {
     with(target) {
       pluginManager.apply("com.google.devtools.ksp")
 
-      // extensions.configure<KspExtension> {
-      //   // The schemas directory contains a schema file for each version of the Room database.
-      //   // This is required to enable Room auto migrations.
-      //   // See https://developer.android.com/reference/kotlin/androidx/room/AutoMigration.
-      //   arg(RoomSchemaArgProvider(File(projectDir, "schemas")))
-      // }
+      extensions.configure<KspExtension> {
+        // The schemas directory contains a schema file for each version of the Room database.
+        // This is required to enable Room auto migrations.
+        // See https://developer.android.com/reference/kotlin/androidx/room/AutoMigration.
+        arg(RoomSchemaArgProvider(File(projectDir, "schemas")))
+      }
 
       val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
       dependencies {

--- a/plugin/library-convention/src/main/kotlin/dev/teogor/ceres/models/RoomOptionsExtension.kt
+++ b/plugin/library-convention/src/main/kotlin/dev/teogor/ceres/models/RoomOptionsExtension.kt
@@ -1,0 +1,14 @@
+package dev.teogor.ceres.models
+
+/**
+ * Extension class for configuring Room-related options.
+ *
+ * @property enableSchemaProvider Set to `true` to enable the RoomSchemaArgProvider.
+ * @property schemasPath The relative path to the directory containing Room database schema files.
+ *                      This path is used when configuring the RoomSchemaArgProvider and is relative
+ *                      to the projectDir. The default value is "schemas."
+ */
+open class RoomOptionsExtension(
+  var enableSchemaProvider: Boolean = false,
+  var schemasPath: String = "schemas",
+)


### PR DESCRIPTION
This PR introduces the `RoomOptionsExtension` to configure schema export settings for the Android Room Convention Plugin. The `RoomOptionsExtension` allows you to fine-tune the behavior of schema export, which is essential for Room database auto migrations and version management.

### Changes Made

- Added the `RoomOptionsExtension` to provide schema export configuration options.
- Enhanced the plugin to dynamically configure schema export settings based on the `RoomOptions` extension.

### How to Use

To configure schema export, you can make use of the `roomOptions` extension in your build.gradle.kts or build.gradle files. For instance, by setting `enableSchemaProvider = true`, you enable schema export. You can also specify the directory where the schema files are stored using `schemasPath`. For example:

```kotlin
roomOptions {
  enableSchemaProvider = true
  schemasPath = "custom_schemas_directory"
}
```

This use case would enable schema export and set the schema directory to "custom_schemas_directory." It ensures that schema files are available for Room auto migrations and version management.

For more details and the benefits of schema export, please refer to the Room documentation on [Exporting Schemas](https://developer.android.com/training/data-storage/room/migrating-db-versions#export-schemas).