### PR TITLE
Enhance AdRequestOptions Extension Functions

### DIFF
--- a/app/src/main/kotlin/dev/teogor/ceres/Application.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/Application.kt
@@ -21,6 +21,9 @@ import dev.teogor.ceres.ads.ApplicationOpenAd
 import dev.teogor.ceres.framework.core.Application
 import dev.teogor.ceres.framework.core.model.ThemeBuilder
 import dev.teogor.ceres.monetisation.admob.AdMob
+import dev.teogor.ceres.monetisation.ads.extensions.setForChildrenApp
+import dev.teogor.ceres.monetisation.ads.extensions.setForEveryoneApp
+import dev.teogor.ceres.monetisation.ads.extensions.setForFamilies
 import dev.teogor.ceres.monetisation.ads.model.AdContentRating
 import dev.teogor.ceres.monetisation.ads.model.TagForChildDirectedTreatment
 import dev.teogor.ceres.monetisation.ads.model.TagForUnderAgeOfConsent
@@ -52,6 +55,10 @@ class Application : Application() {
       maxAdContentRating = AdContentRating.UNSPECIFIED
       tagForChildDirectedTreatment = TagForChildDirectedTreatment.UNSPECIFIED
       tagForUnderAgeOfConsent = TagForUnderAgeOfConsent.UNSPECIFIED
+
+      setForFamilies()
+      setForChildrenApp()
+      setForEveryoneApp()
     }
 
     AdMob.setApplicationOpenAd(applicationOpenAd)

--- a/app/src/main/kotlin/dev/teogor/ceres/Application.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/Application.kt
@@ -21,6 +21,9 @@ import dev.teogor.ceres.ads.ApplicationOpenAd
 import dev.teogor.ceres.framework.core.Application
 import dev.teogor.ceres.framework.core.model.ThemeBuilder
 import dev.teogor.ceres.monetisation.admob.AdMob
+import dev.teogor.ceres.monetisation.ads.model.AdContentRating
+import dev.teogor.ceres.monetisation.ads.model.TagForChildDirectedTreatment
+import dev.teogor.ceres.monetisation.ads.model.TagForUnderAgeOfConsent
 import dev.teogor.ceres.theme.configureTheme
 import javax.inject.Inject
 
@@ -44,6 +47,12 @@ class Application : Application() {
 
   override fun onCreate() {
     super.onCreate()
+
+    AdMob.configureAdRequest {
+      maxAdContentRating = AdContentRating.UNSPECIFIED
+      tagForChildDirectedTreatment = TagForChildDirectedTreatment.UNSPECIFIED
+      tagForUnderAgeOfConsent = TagForUnderAgeOfConsent.UNSPECIFIED
+    }
 
     AdMob.setApplicationOpenAd(applicationOpenAd)
   }

--- a/monetisation/admob/api/admob.api
+++ b/monetisation/admob/api/admob.api
@@ -1,6 +1,7 @@
 public final class dev/teogor/ceres/monetisation/admob/AdMob {
 	public static final field $stable I
 	public static final field INSTANCE Ldev/teogor/ceres/monetisation/admob/AdMob;
+	public final fun configureAdRequest (Lkotlin/jvm/functions/Function1;)V
 	public final fun getAppOpenAd ()Ldev/teogor/ceres/monetisation/admob/formats/AppOpenAd;
 	public final fun setApplicationOpenAd (Ldev/teogor/ceres/monetisation/admob/formats/AppOpenAd;)V
 }
@@ -9,8 +10,13 @@ public final class dev/teogor/ceres/monetisation/admob/AdMobInitializer {
 	public static final field $stable I
 	public static final field INSTANCE Ldev/teogor/ceres/monetisation/admob/AdMobInitializer;
 	public final fun configureAdsControl (Ldev/teogor/ceres/monetisation/ads/AdsControl;)V
-	public final fun getHashedAdvertisingId (Landroid/content/Context;)Ljava/lang/String;
 	public final fun initialize (Landroid/content/Context;)V
+}
+
+public final class dev/teogor/ceres/monetisation/admob/AdMobInitializerKt {
+	public static final fun getHashedAdvertisingId (Landroid/content/Context;)Ljava/lang/String;
+	public static final fun getRequestConfiguration (Ldev/teogor/ceres/monetisation/ads/model/AdRequestOptions;Lkotlin/jvm/functions/Function1;)Lcom/google/android/gms/ads/RequestConfiguration;
+	public static synthetic fun getRequestConfiguration$default (Ldev/teogor/ceres/monetisation/ads/model/AdRequestOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/google/android/gms/ads/RequestConfiguration;
 }
 
 public final class dev/teogor/ceres/monetisation/admob/AdmobManagerInitializer : androidx/startup/Initializer {

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/AdMob.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/AdMob.kt
@@ -16,7 +16,10 @@
 
 package dev.teogor.ceres.monetisation.admob
 
+import com.google.android.gms.ads.MobileAds
 import dev.teogor.ceres.monetisation.admob.formats.AppOpenAd
+import dev.teogor.ceres.monetisation.ads.ExperimentalAdsControlApi
+import dev.teogor.ceres.monetisation.ads.model.AdRequestOptions
 import java.lang.ref.WeakReference
 
 object AdMob {
@@ -29,4 +32,12 @@ object AdMob {
   }
 
   fun getAppOpenAd() = weakRefAppOpenAd.get()
+
+  @OptIn(ExperimentalAdsControlApi::class)
+  fun configureAdRequest(
+    block: AdRequestOptions.() -> Unit,
+  ) {
+    val adRequestOptions = AdMobInitializer.adsControl.adRequestOptions.value.apply(block)
+    MobileAds.setRequestConfiguration(getRequestConfiguration(adRequestOptions))
+  }
 }

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/AdMobInitializer.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/AdMobInitializer.kt
@@ -28,6 +28,7 @@ import dev.teogor.ceres.core.runtime.AppMetadataManager
 import dev.teogor.ceres.monetisation.ads.AdsControl
 import dev.teogor.ceres.monetisation.ads.AdsControlProvider
 import dev.teogor.ceres.monetisation.ads.ExperimentalAdsControlApi
+import dev.teogor.ceres.monetisation.ads.model.AdRequestOptions
 import java.io.UnsupportedEncodingException
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
@@ -36,22 +37,11 @@ object AdMobInitializer {
 
   private var connectivityManager: ConnectivityManagerNetworkMonitor? = null
 
-  @SuppressLint("HardwareIds")
-  fun getHashedAdvertisingId(
-    context: Context,
-  ): String {
-    val androidId: String = Settings.Secure.getString(
-      context.contentResolver,
-      Settings.Secure.ANDROID_ID,
-    )
-    return md5(androidId)?.uppercase() ?: ""
-  }
-
   fun configureAdsControl(adsControl: AdsControl) {
     AdsControlProvider.initialize(adsControl)
   }
 
-  private val adsControl: AdsControl
+  internal val adsControl: AdsControl
     get() = AdsControlProvider.adsControl
 
   fun initialize(context: Context) {
@@ -65,19 +55,51 @@ object AdMobInitializer {
       MobileAds.setRequestConfiguration(configuration)
     }
   }
+}
 
-  private fun md5(md5: String): String? {
-    try {
-      val md = MessageDigest.getInstance("MD5")
-      val array = md.digest(md5.toByteArray(charset("UTF-8")))
-      val sb = StringBuffer()
-      for (i in array.indices) {
-        sb.append(Integer.toHexString(array[i].toInt() and 0xFF or 0x100).substring(1, 3))
-      }
-      return sb.toString()
-    } catch (_: NoSuchAlgorithmException) {
-    } catch (_: UnsupportedEncodingException) {
+inline fun getRequestConfiguration(
+  adRequestOptions: AdRequestOptions,
+  crossinline block: RequestConfiguration.Builder.() -> Unit = {},
+): RequestConfiguration {
+  return MobileAds.getRequestConfiguration()
+    .toBuilder()
+    .apply {
+      setTagForChildDirectedTreatment(
+        adRequestOptions.tagForChildDirectedTreatment.intValue,
+      )
+      setMaxAdContentRating(
+        adRequestOptions.maxAdContentRating.stringValue,
+      )
+      setTagForUnderAgeOfConsent(
+        adRequestOptions.tagForUnderAgeOfConsent.intValue,
+      )
+      block()
     }
-    return null
+    .build()
+}
+
+@SuppressLint("HardwareIds")
+fun getHashedAdvertisingId(
+  context: Context,
+): String {
+  val androidId: String = Settings.Secure.getString(
+    context.contentResolver,
+    Settings.Secure.ANDROID_ID,
+  )
+  return md5(androidId)?.uppercase() ?: ""
+}
+
+private fun md5(md5: String): String? {
+  try {
+    val md = MessageDigest.getInstance("MD5")
+    val array = md.digest(md5.toByteArray(charset("UTF-8")))
+    val sb = StringBuffer()
+    for (i in array.indices) {
+      sb.append(Integer.toHexString(array[i].toInt() and 0xFF or 0x100).substring(1, 3))
+    }
+    return sb.toString()
+  } catch (_: NoSuchAlgorithmException) {
+  } catch (_: UnsupportedEncodingException) {
   }
+  return null
 }

--- a/monetisation/ads/api/ads.api
+++ b/monetisation/ads/api/ads.api
@@ -1,4 +1,5 @@
 public abstract interface class dev/teogor/ceres/monetisation/ads/AdsControl {
+	public abstract fun getAdRequestOptions ()Landroidx/compose/runtime/MutableState;
 	public abstract fun getCanRequestAds ()Landroidx/compose/runtime/MutableState;
 	public abstract fun getConsentRequirementStatus ()Landroidx/compose/runtime/MutableState;
 	public abstract fun getConsentStatus ()Landroidx/compose/runtime/MutableState;
@@ -26,16 +27,18 @@ public final class dev/teogor/ceres/monetisation/ads/AdsControlProvider {
 public final class dev/teogor/ceres/monetisation/ads/AndroidAdsControl : dev/teogor/ceres/monetisation/ads/AdsControl {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Landroidx/compose/runtime/MutableState;
 	public final fun component2 ()Landroidx/compose/runtime/MutableState;
 	public final fun component3 ()Landroidx/compose/runtime/MutableState;
-	public final fun component4 ()Lkotlin/jvm/functions/Function0;
+	public final fun component4 ()Landroidx/compose/runtime/MutableState;
 	public final fun component5 ()Lkotlin/jvm/functions/Function0;
-	public final fun copy (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;
+	public final fun component6 ()Lkotlin/jvm/functions/Function0;
+	public final fun copy (Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ldev/teogor/ceres/monetisation/ads/AndroidAdsControl;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAdRequestOptions ()Landroidx/compose/runtime/MutableState;
 	public fun getCanRequestAds ()Landroidx/compose/runtime/MutableState;
 	public fun getConsentRequirementStatus ()Landroidx/compose/runtime/MutableState;
 	public fun getConsentStatus ()Landroidx/compose/runtime/MutableState;
@@ -48,6 +51,39 @@ public final class dev/teogor/ceres/monetisation/ads/AndroidAdsControl : dev/teo
 }
 
 public abstract interface annotation class dev/teogor/ceres/monetisation/ads/ExperimentalAdsControlApi : java/lang/annotation/Annotation {
+}
+
+public final class dev/teogor/ceres/monetisation/ads/model/AdContentRating : java/lang/Enum {
+	public static final field G Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;
+	public static final field MA Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;
+	public static final field PG Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;
+	public static final field T Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;
+	public static final field UNSPECIFIED Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getStringValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;
+	public static fun values ()[Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;
+}
+
+public final class dev/teogor/ceres/monetisation/ads/model/AdRequestOptions {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;Ldev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment;Ldev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent;)V
+	public synthetic fun <init> (Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;Ldev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment;Ldev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;
+	public final fun component2 ()Ldev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment;
+	public final fun component3 ()Ldev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent;
+	public final fun copy (Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;Ldev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment;Ldev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent;)Ldev/teogor/ceres/monetisation/ads/model/AdRequestOptions;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/ads/model/AdRequestOptions;Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;Ldev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment;Ldev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent;ILjava/lang/Object;)Ldev/teogor/ceres/monetisation/ads/model/AdRequestOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxAdContentRating ()Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;
+	public final fun getTagForChildDirectedTreatment ()Ldev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment;
+	public final fun getTagForUnderAgeOfConsent ()Ldev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent;
+	public fun hashCode ()I
+	public final fun setMaxAdContentRating (Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;)V
+	public final fun setTagForChildDirectedTreatment (Ldev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment;)V
+	public final fun setTagForUnderAgeOfConsent (Ldev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent;)V
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/teogor/ceres/monetisation/ads/model/ConsentRequirementStatus : java/lang/Enum {
@@ -69,5 +105,25 @@ public final class dev/teogor/ceres/monetisation/ads/model/ConsentStatus : java/
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Ldev/teogor/ceres/monetisation/ads/model/ConsentStatus;
 	public static fun values ()[Ldev/teogor/ceres/monetisation/ads/model/ConsentStatus;
+}
+
+public final class dev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment : java/lang/Enum {
+	public static final field FALSE Ldev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment;
+	public static final field TRUE Ldev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment;
+	public static final field UNSPECIFIED Ldev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getIntValue ()I
+	public static fun valueOf (Ljava/lang/String;)Ldev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment;
+	public static fun values ()[Ldev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment;
+}
+
+public final class dev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent : java/lang/Enum {
+	public static final field FALSE Ldev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent;
+	public static final field TRUE Ldev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent;
+	public static final field UNSPECIFIED Ldev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getIntValue ()I
+	public static fun valueOf (Ljava/lang/String;)Ldev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent;
+	public static fun values ()[Ldev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent;
 }
 

--- a/monetisation/ads/api/ads.api
+++ b/monetisation/ads/api/ads.api
@@ -53,6 +53,15 @@ public final class dev/teogor/ceres/monetisation/ads/AndroidAdsControl : dev/teo
 public abstract interface annotation class dev/teogor/ceres/monetisation/ads/ExperimentalAdsControlApi : java/lang/annotation/Annotation {
 }
 
+public final class dev/teogor/ceres/monetisation/ads/extensions/AdRequestOptionsExtensionsKt {
+	public static final fun setForAdults (Ldev/teogor/ceres/monetisation/ads/model/AdRequestOptions;)V
+	public static final fun setForChildrenApp (Ldev/teogor/ceres/monetisation/ads/model/AdRequestOptions;)V
+	public static final fun setForEveryoneApp (Ldev/teogor/ceres/monetisation/ads/model/AdRequestOptions;)V
+	public static final fun setForFamilies (Ldev/teogor/ceres/monetisation/ads/model/AdRequestOptions;ZZ)V
+	public static synthetic fun setForFamilies$default (Ldev/teogor/ceres/monetisation/ads/model/AdRequestOptions;ZZILjava/lang/Object;)V
+	public static final fun setForTeens (Ldev/teogor/ceres/monetisation/ads/model/AdRequestOptions;)V
+}
+
 public final class dev/teogor/ceres/monetisation/ads/model/AdContentRating : java/lang/Enum {
 	public static final field G Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;
 	public static final field MA Ldev/teogor/ceres/monetisation/ads/model/AdContentRating;

--- a/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/AdsControl.kt
+++ b/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/AdsControl.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import dev.teogor.ceres.monetisation.ads.model.AdRequestOptions
 import dev.teogor.ceres.monetisation.ads.model.ConsentRequirementStatus
 import dev.teogor.ceres.monetisation.ads.model.ConsentStatus
 
@@ -40,6 +41,10 @@ data class AndroidAdsControl(
   override val consentRequirementStatus: MutableState<ConsentRequirementStatus> = mutableStateOf(
     ConsentRequirementStatus.UNKNOWN,
   ),
+  override val adRequestOptions: MutableState<AdRequestOptions> = mutableStateOf(
+    AdRequestOptions(),
+  ),
+
   val showConsent: (() -> Unit)? = null,
   val resetConsent: (() -> Unit)? = null,
 ) : AdsControl {
@@ -69,6 +74,7 @@ interface AdsControl {
   val canRequestAds: MutableState<Boolean>
   val consentStatus: MutableState<ConsentStatus>
   val consentRequirementStatus: MutableState<ConsentRequirementStatus>
+  val adRequestOptions: MutableState<AdRequestOptions>
 
   fun showConsent()
 

--- a/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/extensions/AdRequestOptionsExtensions.kt
+++ b/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/extensions/AdRequestOptionsExtensions.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.monetisation.ads.extensions
+
+import dev.teogor.ceres.monetisation.ads.model.AdContentRating
+import dev.teogor.ceres.monetisation.ads.model.AdRequestOptions
+import dev.teogor.ceres.monetisation.ads.model.TagForChildDirectedTreatment
+import dev.teogor.ceres.monetisation.ads.model.TagForUnderAgeOfConsent
+
+/**
+ * Extension function to configure AdRequestOptions for "Apps designed
+ * specifically for children."
+ *
+ * These apps must use Google Play Families self-certified ads SDKs and
+ * set properties for compliance.
+ */
+fun AdRequestOptions.setForChildrenApp() {
+  maxAdContentRating = AdContentRating.G
+  tagForChildDirectedTreatment = TagForChildDirectedTreatment.TRUE
+  tagForUnderAgeOfConsent = TagForUnderAgeOfConsent.FALSE
+}
+
+/**
+ * Extension function to configure AdRequestOptions for "Families".
+ * These apps must use Google Play Families self-certified ads SDKs and
+ * set properties for compliance.
+ *
+ * @param primarilyChildDirected Set to true for apps primarily child-directed
+ *                               where the maximum ad content rating will be "G".
+ * @param mixedAudience Set to true for apps with a mixed audience where the maximum
+ *                      ad content rating will be "PG" if greater than PG.
+ */
+fun AdRequestOptions.setForFamilies(
+  primarilyChildDirected: Boolean = false,
+  mixedAudience: Boolean = false,
+) {
+  maxAdContentRating = when {
+    primarilyChildDirected -> AdContentRating.G
+    mixedAudience -> AdContentRating.PG
+    else -> AdContentRating.G // Default for other cases
+  }
+  tagForChildDirectedTreatment = TagForChildDirectedTreatment.TRUE
+  tagForUnderAgeOfConsent = TagForUnderAgeOfConsent.FALSE
+}
+
+/**
+ * Extension function to configure AdRequestOptions for "Apps for everyone,
+ * including children and families."
+ *
+ * These apps must use Google Play Families self-certified ads SDKs and set
+ * properties for compliance.
+ */
+fun AdRequestOptions.setForEveryoneApp() {
+  maxAdContentRating = AdContentRating.G
+  tagForChildDirectedTreatment = TagForChildDirectedTreatment.TRUE
+  tagForUnderAgeOfConsent = TagForUnderAgeOfConsent.FALSE
+}
+
+/**
+ * Extension function to configure AdRequestOptions for "Teens".
+ *
+ * Set ad content rating to "T" (Teen) and tag for child-directed treatment
+ * to false.
+ */
+fun AdRequestOptions.setForTeens() {
+  maxAdContentRating = AdContentRating.T
+  tagForChildDirectedTreatment = TagForChildDirectedTreatment.FALSE
+  tagForUnderAgeOfConsent = TagForUnderAgeOfConsent.FALSE
+}
+
+/**
+ * Extension function to configure AdRequestOptions for "Adults".
+ *
+ * Set ad content rating to "MA" (Mature) and tag for child-directed treatment
+ * to false.
+ */
+fun AdRequestOptions.setForAdults() {
+  maxAdContentRating = AdContentRating.MA
+  tagForChildDirectedTreatment = TagForChildDirectedTreatment.FALSE
+  tagForUnderAgeOfConsent = TagForUnderAgeOfConsent.FALSE
+}

--- a/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/model/AdContentRating.kt
+++ b/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/model/AdContentRating.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.monetisation.ads.model
+
+enum class AdContentRating(val stringValue: String) {
+  UNSPECIFIED(""),
+  G("G"),
+  PG("PG"),
+  T("T"),
+  MA("MA"),
+}

--- a/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/model/AdRequestOptions.kt
+++ b/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/model/AdRequestOptions.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.monetisation.ads.model
+
+/**
+ * Data class representing options for configuring a request configuration for ad requests.
+ *
+ * @property maxAdContentRating The option for setting the maximum ad content rating.
+ * @property tagForChildDirectedTreatment The option for setting child-directed treatment.
+ * @property tagForUnderAgeOfConsent The option for setting under-age-of-consent treatment.
+ */
+data class AdRequestOptions(
+  var maxAdContentRating: AdContentRating = AdContentRating.UNSPECIFIED,
+  var tagForChildDirectedTreatment: TagForChildDirectedTreatment = TagForChildDirectedTreatment.UNSPECIFIED,
+  var tagForUnderAgeOfConsent: TagForUnderAgeOfConsent = TagForUnderAgeOfConsent.UNSPECIFIED,
+)

--- a/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment.kt
+++ b/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/model/TagForChildDirectedTreatment.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.monetisation.ads.model
+
+enum class TagForChildDirectedTreatment(val intValue: Int) {
+  UNSPECIFIED(-1),
+  FALSE(0),
+  TRUE(1),
+}

--- a/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent.kt
+++ b/monetisation/ads/src/main/kotlin/dev/teogor/ceres/monetisation/ads/model/TagForUnderAgeOfConsent.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.monetisation.ads.model
+
+enum class TagForUnderAgeOfConsent(val intValue: Int) {
+  UNSPECIFIED(-1),
+  FALSE(0),
+  TRUE(1),
+}

--- a/monetisation/messaging/src/main/kotlin/dev/teogor/ceres/monetisation/messaging/ConsentManager.kt
+++ b/monetisation/messaging/src/main/kotlin/dev/teogor/ceres/monetisation/messaging/ConsentManager.kt
@@ -28,7 +28,7 @@ import com.google.android.ump.UserMessagingPlatform
 import dev.teogor.ceres.core.runtime.AppMetadataManager
 import dev.teogor.ceres.monetisation.admob.AdMob
 import dev.teogor.ceres.monetisation.admob.AdMobInitializer
-import dev.teogor.ceres.monetisation.admob.AdMobInitializer.getHashedAdvertisingId
+import dev.teogor.ceres.monetisation.admob.getHashedAdvertisingId
 import dev.teogor.ceres.monetisation.ads.AdsControl
 import dev.teogor.ceres.monetisation.ads.AdsControlProvider
 import dev.teogor.ceres.monetisation.ads.ExperimentalAdsControlApi


### PR DESCRIPTION
This PR introduces enhancements to the extension functions for configuring `AdRequestOptions` related to ad content ratings and compliance with various app categories.

### Changes Made

#### Refinement of Existing Extension Functions

The existing extension functions for configuring `AdRequestOptions` have been refined and extended to include additional scenarios. The following extension functions are now available:

- `setForChildrenApp()`: Configures options for apps designed specifically for children.
- `setForFamilies()`: Configures options for apps targeting families, with support for primarily child-directed and mixed-audience apps.
- `setForEveryoneApp()`: Configures options for apps targeting everyone, including children and families.
- `setForTeens()`: Configures options for apps targeting teens.
- `setForAdults()`: Configures options for apps targeting adults.

These extension functions provide a streamlined way to set the appropriate content rating and treatment options for ads, ensuring compliance with policies and regulations across different app categories.

### How to Use

You can utilize the extension functions to configure `AdRequestOptions` for various app categories as needed. The method for configuring `AdRequestOptions` depends on your context:

- If you are within a Composable context, you can access the `AdRequestOptions` via `LocalAdsControl.current`:

  ```kotlin
  val adsControl = LocalAdsControl.current
  adsControl.adRequestOptions.apply {
    maxAdContentRating = AdContentRating.UNSPECIFIED
    tagForChildDirectedTreatment = TagForChildDirectedTreatment.UNSPECIFIED
    tagForUnderAgeOfConsent = TagForUnderAgeOfConsent.UNSPECIFIED
  }
  ```

- If you are outside of a Composable context, you can use `AdMob.configureAdRequest`:

  ```kotlin
  AdMob.configureAdRequest {
    maxAdContentRating = AdContentRating.UNSPECIFIED
    tagForChildDirectedTreatment = TagForChildDirectedTreatment.UNSPECIFIED
    tagForUnderAgeOfConsent = TagForUnderAgeOfConsent.UNSPECIFIED

    setForFamilies()         // Configure for apps targeting families
    setForChildrenApp()      // Configure for apps designed for children
    setForEveryoneApp()      // Configure for apps targeting everyone, including children and families
  }
  ```

Choose the appropriate method based on your context to configure `AdRequestOptions` for your application's specific requirements.

This allows you to easily set the appropriate ad content rating and treatment options for ads within your application.