### PR TITLE
Ad Caching and Loading Enhancements

### DIFF
--- a/monetisation/admob/api/admob.api
+++ b/monetisation/admob/api/admob.api
@@ -80,6 +80,7 @@ public abstract class dev/teogor/ceres/monetisation/admob/formats/Ad : dev/teogo
 	public abstract fun loadContinuously ()Z
 	public fun log (Ljava/lang/String;)V
 	public final fun onListener (Ldev/teogor/ceres/monetisation/admob/formats/AdEvent;)V
+	public fun reloadExpiredAd ()V
 	protected final fun setLoading (Z)V
 	protected final fun setShowing (Z)V
 	public fun show ()V
@@ -211,6 +212,11 @@ public final class dev/teogor/ceres/monetisation/admob/formats/AdType : java/lan
 	public final fun type ()Ldev/teogor/ceres/monetisation/admob/formats/AdType;
 	public static fun valueOf (Ljava/lang/String;)Ldev/teogor/ceres/monetisation/admob/formats/AdType;
 	public static fun values ()[Ldev/teogor/ceres/monetisation/admob/formats/AdType;
+}
+
+public final class dev/teogor/ceres/monetisation/admob/formats/AdTypeKt {
+	public static final fun toFriendlyName (Ldev/teogor/ceres/monetisation/admob/formats/AdType;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static synthetic fun toFriendlyName$default (Ldev/teogor/ceres/monetisation/admob/formats/AdType;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
 }
 
 public abstract class dev/teogor/ceres/monetisation/admob/formats/AppOpenAd : dev/teogor/ceres/monetisation/admob/formats/Ad {

--- a/monetisation/admob/api/admob.api
+++ b/monetisation/admob/api/admob.api
@@ -242,64 +242,76 @@ public abstract class dev/teogor/ceres/monetisation/admob/formats/BannerAd : dev
 
 public abstract class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel {
 	public static final field $stable I
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getLoadTime ()J
 }
 
 public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$AppOpen : dev/teogor/ceres/monetisation/admob/formats/CacheAdModel {
 	public static final field $stable I
-	public fun <init> (Lcom/google/android/gms/ads/appopen/AppOpenAd;)V
+	public fun <init> (Lcom/google/android/gms/ads/appopen/AppOpenAd;J)V
 	public final fun component1 ()Lcom/google/android/gms/ads/appopen/AppOpenAd;
-	public final fun copy (Lcom/google/android/gms/ads/appopen/AppOpenAd;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$AppOpen;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$AppOpen;Lcom/google/android/gms/ads/appopen/AppOpenAd;ILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$AppOpen;
+	public final fun component2 ()J
+	public final fun copy (Lcom/google/android/gms/ads/appopen/AppOpenAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$AppOpen;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$AppOpen;Lcom/google/android/gms/ads/appopen/AppOpenAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$AppOpen;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAd ()Lcom/google/android/gms/ads/appopen/AppOpenAd;
+	public fun getLoadTime ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Interstitial : dev/teogor/ceres/monetisation/admob/formats/CacheAdModel {
 	public static final field $stable I
-	public fun <init> (Lcom/google/android/gms/ads/interstitial/InterstitialAd;)V
+	public fun <init> (Lcom/google/android/gms/ads/interstitial/InterstitialAd;J)V
 	public final fun component1 ()Lcom/google/android/gms/ads/interstitial/InterstitialAd;
-	public final fun copy (Lcom/google/android/gms/ads/interstitial/InterstitialAd;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Interstitial;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Interstitial;Lcom/google/android/gms/ads/interstitial/InterstitialAd;ILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Interstitial;
+	public final fun component2 ()J
+	public final fun copy (Lcom/google/android/gms/ads/interstitial/InterstitialAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Interstitial;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Interstitial;Lcom/google/android/gms/ads/interstitial/InterstitialAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Interstitial;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAd ()Lcom/google/android/gms/ads/interstitial/InterstitialAd;
+	public fun getLoadTime ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Native : dev/teogor/ceres/monetisation/admob/formats/CacheAdModel {
 	public static final field $stable I
-	public fun <init> (Lcom/google/android/gms/ads/nativead/NativeAd;)V
+	public fun <init> (Lcom/google/android/gms/ads/nativead/NativeAd;J)V
 	public final fun component1 ()Lcom/google/android/gms/ads/nativead/NativeAd;
-	public final fun copy (Lcom/google/android/gms/ads/nativead/NativeAd;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Native;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Native;Lcom/google/android/gms/ads/nativead/NativeAd;ILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Native;
+	public final fun component2 ()J
+	public final fun copy (Lcom/google/android/gms/ads/nativead/NativeAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Native;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Native;Lcom/google/android/gms/ads/nativead/NativeAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Native;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAd ()Lcom/google/android/gms/ads/nativead/NativeAd;
+	public fun getLoadTime ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Rewarded : dev/teogor/ceres/monetisation/admob/formats/CacheAdModel {
 	public static final field $stable I
-	public fun <init> (Lcom/google/android/gms/ads/rewarded/RewardedAd;)V
+	public fun <init> (Lcom/google/android/gms/ads/rewarded/RewardedAd;J)V
 	public final fun component1 ()Lcom/google/android/gms/ads/rewarded/RewardedAd;
-	public final fun copy (Lcom/google/android/gms/ads/rewarded/RewardedAd;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Rewarded;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Rewarded;Lcom/google/android/gms/ads/rewarded/RewardedAd;ILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Rewarded;
+	public final fun component2 ()J
+	public final fun copy (Lcom/google/android/gms/ads/rewarded/RewardedAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Rewarded;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Rewarded;Lcom/google/android/gms/ads/rewarded/RewardedAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Rewarded;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAd ()Lcom/google/android/gms/ads/rewarded/RewardedAd;
+	public fun getLoadTime ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$RewardedInterstitial : dev/teogor/ceres/monetisation/admob/formats/CacheAdModel {
 	public static final field $stable I
-	public fun <init> (Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;)V
+	public fun <init> (Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;J)V
 	public final fun component1 ()Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;
-	public final fun copy (Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$RewardedInterstitial;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$RewardedInterstitial;Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;ILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$RewardedInterstitial;
+	public final fun component2 ()J
+	public final fun copy (Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$RewardedInterstitial;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$RewardedInterstitial;Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$RewardedInterstitial;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAd ()Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;
+	public fun getLoadTime ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/monetisation/admob/api/admob.api
+++ b/monetisation/admob/api/admob.api
@@ -90,8 +90,8 @@ public abstract class dev/teogor/ceres/monetisation/admob/formats/Ad : dev/teogo
 public final class dev/teogor/ceres/monetisation/admob/formats/AdCache {
 	public static final field $stable I
 	public static final field INSTANCE Ldev/teogor/ceres/monetisation/admob/formats/AdCache;
-	public final fun cacheAd (Ljava/lang/String;Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel;)V
-	public final fun getAd (Ljava/lang/String;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel;
+	public final fun cacheAd (Ljava/lang/String;Ldev/teogor/ceres/monetisation/admob/formats/CachedAd;)V
+	public final fun getAd (Ljava/lang/String;)Ldev/teogor/ceres/monetisation/admob/formats/CachedAd;
 	public final fun getAdCount (Ljava/lang/String;)I
 	public final fun getAds (Ljava/lang/String;I)Ljava/util/List;
 	public final fun removeAd (Ljava/lang/String;)V
@@ -240,19 +240,19 @@ public abstract class dev/teogor/ceres/monetisation/admob/formats/BannerAd : dev
 	public fun useCache ()Z
 }
 
-public abstract class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel {
+public abstract class dev/teogor/ceres/monetisation/admob/formats/CachedAd {
 	public static final field $stable I
 	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getLoadTime ()J
 }
 
-public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$AppOpen : dev/teogor/ceres/monetisation/admob/formats/CacheAdModel {
+public final class dev/teogor/ceres/monetisation/admob/formats/CachedAd$AppOpen : dev/teogor/ceres/monetisation/admob/formats/CachedAd {
 	public static final field $stable I
 	public fun <init> (Lcom/google/android/gms/ads/appopen/AppOpenAd;J)V
 	public final fun component1 ()Lcom/google/android/gms/ads/appopen/AppOpenAd;
 	public final fun component2 ()J
-	public final fun copy (Lcom/google/android/gms/ads/appopen/AppOpenAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$AppOpen;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$AppOpen;Lcom/google/android/gms/ads/appopen/AppOpenAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$AppOpen;
+	public final fun copy (Lcom/google/android/gms/ads/appopen/AppOpenAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$AppOpen;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$AppOpen;Lcom/google/android/gms/ads/appopen/AppOpenAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$AppOpen;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAd ()Lcom/google/android/gms/ads/appopen/AppOpenAd;
 	public fun getLoadTime ()J
@@ -260,13 +260,13 @@ public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$AppO
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Interstitial : dev/teogor/ceres/monetisation/admob/formats/CacheAdModel {
+public final class dev/teogor/ceres/monetisation/admob/formats/CachedAd$Interstitial : dev/teogor/ceres/monetisation/admob/formats/CachedAd {
 	public static final field $stable I
 	public fun <init> (Lcom/google/android/gms/ads/interstitial/InterstitialAd;J)V
 	public final fun component1 ()Lcom/google/android/gms/ads/interstitial/InterstitialAd;
 	public final fun component2 ()J
-	public final fun copy (Lcom/google/android/gms/ads/interstitial/InterstitialAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Interstitial;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Interstitial;Lcom/google/android/gms/ads/interstitial/InterstitialAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Interstitial;
+	public final fun copy (Lcom/google/android/gms/ads/interstitial/InterstitialAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$Interstitial;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$Interstitial;Lcom/google/android/gms/ads/interstitial/InterstitialAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$Interstitial;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAd ()Lcom/google/android/gms/ads/interstitial/InterstitialAd;
 	public fun getLoadTime ()J
@@ -274,13 +274,13 @@ public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Inte
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Native : dev/teogor/ceres/monetisation/admob/formats/CacheAdModel {
+public final class dev/teogor/ceres/monetisation/admob/formats/CachedAd$Native : dev/teogor/ceres/monetisation/admob/formats/CachedAd {
 	public static final field $stable I
 	public fun <init> (Lcom/google/android/gms/ads/nativead/NativeAd;J)V
 	public final fun component1 ()Lcom/google/android/gms/ads/nativead/NativeAd;
 	public final fun component2 ()J
-	public final fun copy (Lcom/google/android/gms/ads/nativead/NativeAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Native;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Native;Lcom/google/android/gms/ads/nativead/NativeAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Native;
+	public final fun copy (Lcom/google/android/gms/ads/nativead/NativeAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$Native;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$Native;Lcom/google/android/gms/ads/nativead/NativeAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$Native;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAd ()Lcom/google/android/gms/ads/nativead/NativeAd;
 	public fun getLoadTime ()J
@@ -288,13 +288,13 @@ public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Nati
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Rewarded : dev/teogor/ceres/monetisation/admob/formats/CacheAdModel {
+public final class dev/teogor/ceres/monetisation/admob/formats/CachedAd$Rewarded : dev/teogor/ceres/monetisation/admob/formats/CachedAd {
 	public static final field $stable I
 	public fun <init> (Lcom/google/android/gms/ads/rewarded/RewardedAd;J)V
 	public final fun component1 ()Lcom/google/android/gms/ads/rewarded/RewardedAd;
 	public final fun component2 ()J
-	public final fun copy (Lcom/google/android/gms/ads/rewarded/RewardedAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Rewarded;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Rewarded;Lcom/google/android/gms/ads/rewarded/RewardedAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Rewarded;
+	public final fun copy (Lcom/google/android/gms/ads/rewarded/RewardedAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$Rewarded;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$Rewarded;Lcom/google/android/gms/ads/rewarded/RewardedAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$Rewarded;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAd ()Lcom/google/android/gms/ads/rewarded/RewardedAd;
 	public fun getLoadTime ()J
@@ -302,13 +302,13 @@ public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$Rewa
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/teogor/ceres/monetisation/admob/formats/CacheAdModel$RewardedInterstitial : dev/teogor/ceres/monetisation/admob/formats/CacheAdModel {
+public final class dev/teogor/ceres/monetisation/admob/formats/CachedAd$RewardedInterstitial : dev/teogor/ceres/monetisation/admob/formats/CachedAd {
 	public static final field $stable I
 	public fun <init> (Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;J)V
 	public final fun component1 ()Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;
 	public final fun component2 ()J
-	public final fun copy (Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$RewardedInterstitial;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$RewardedInterstitial;Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CacheAdModel$RewardedInterstitial;
+	public final fun copy (Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;J)Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$RewardedInterstitial;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$RewardedInterstitial;Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;JILjava/lang/Object;)Ldev/teogor/ceres/monetisation/admob/formats/CachedAd$RewardedInterstitial;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAd ()Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;
 	public fun getLoadTime ()J

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/Ad.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/Ad.kt
@@ -75,6 +75,14 @@ abstract class Ad(
 
   open fun show() = Unit
 
+  open fun reloadExpiredAd() {
+    val adTypeName = type().toFriendlyName(suffix = " Ad")
+    log("Loading a new $adTypeName to replace the expired ad.")
+    AdCache.removeAd(id)
+
+    load()
+  }
+
   fun onListener(event: AdEvent) {
     log("onListener::$event")
     when (event) {

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/AdCache.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/AdCache.kt
@@ -17,11 +17,11 @@
 package dev.teogor.ceres.monetisation.admob.formats
 
 object AdCache {
-  private val adCache: MutableMap<String, MutableList<CacheAdModel>> = mutableMapOf()
+  private val cachedAds: MutableMap<String, MutableList<CachedAd>> = mutableMapOf()
 
   @Synchronized
-  fun cacheAd(adId: String, ad: CacheAdModel) {
-    adCache.getOrPut(adId) {
+  fun cacheAd(adId: String, ad: CachedAd) {
+    cachedAds.getOrPut(adId) {
       mutableListOf()
     }.apply {
       add(ad)
@@ -29,27 +29,27 @@ object AdCache {
   }
 
   @Synchronized
-  fun getAd(adId: String): CacheAdModel? {
-    return adCache[adId]?.firstOrNull()
+  fun getAd(adId: String): CachedAd? {
+    return cachedAds[adId]?.firstOrNull()
   }
 
   @Synchronized
-  fun getAds(adId: String, count: Int): List<CacheAdModel> {
-    return adCache[adId]?.take(count) ?: emptyList()
+  fun getAds(adId: String, count: Int): List<CachedAd> {
+    return cachedAds[adId]?.take(count) ?: emptyList()
   }
 
   @Synchronized
   fun removeAd(adId: String) {
-    adCache[adId]?.let { adList ->
+    cachedAds[adId]?.let { adList ->
       if (adList.isNotEmpty()) {
         adList.removeAt(0)
       }
       if (adList.isEmpty()) {
-        adCache.remove(adId)
+        cachedAds.remove(adId)
       }
     }
   }
 
   @Synchronized
-  fun getAdCount(adId: String) = adCache[adId]?.size ?: 0
+  fun getAdCount(adId: String) = cachedAds[adId]?.size ?: 0
 }

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/AdType.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/AdType.kt
@@ -28,8 +28,33 @@ enum class AdType {
   Native,
   NativeVideo,
   Rewarded,
-  Unspecified,
-  ;
+  Unspecified;
 
   fun type(): AdType = this
+}
+
+/**
+ * Converts an AdType to a user-friendly name with an optional prefix and suffix.
+ *
+ * @param prefix The prefix to add to the friendly name.
+ * @param suffix The suffix to add to the friendly name.
+ * @return The user-friendly name of the AdType.
+ */
+fun AdType.toFriendlyName(
+  prefix: String = "",
+  suffix: String = "",
+): String {
+  return this.name
+    .split(Regex("(?=[A-Z])"))
+    .joinToString(" ") {
+      it.replaceFirstChar { char ->
+        if (char.isLowerCase()) {
+          char.titlecase()
+        } else {
+          char.toString()
+        }
+      }
+    }
+    .trim()
+    .let { "$prefix$it$suffix" }
 }

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/AdType.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/AdType.kt
@@ -28,7 +28,8 @@ enum class AdType {
   Native,
   NativeVideo,
   Rewarded,
-  Unspecified;
+  Unspecified,
+  ;
 
   fun type(): AdType = this
 }

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/AppOpenAd.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/AppOpenAd.kt
@@ -23,6 +23,7 @@ import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.appopen.AppOpenAd
 import dev.teogor.ceres.monetisation.admob.CurrentActivityHolder
 import java.util.Date
+import java.util.concurrent.TimeUnit
 
 abstract class AppOpenAd : Ad() {
 
@@ -95,8 +96,7 @@ abstract class AppOpenAd : Ad() {
     }
 
     if (!wasLoadTimeLessThanNHoursAgo(4)) {
-      log("Loading the app open ad because the previously loaded ad has expired.")
-      load()
+      reloadExpiredAd()
       return
     } else {
       log("App open ad is still valid; no need to reload.")
@@ -154,7 +154,7 @@ abstract class AppOpenAd : Ad() {
 
   private fun wasLoadTimeLessThanNHoursAgo(numHours: Long): Boolean {
     val dateDifference: Long = Date().time - loadTime
-    val numMilliSecondsPerHour: Long = 3600000
+    val numMilliSecondsPerHour: Long = TimeUnit.HOURS.toMillis(1)
     return dateDifference < numMilliSecondsPerHour * numHours
   }
 }

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/AppOpenAd.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/AppOpenAd.kt
@@ -53,7 +53,7 @@ abstract class AppOpenAd : Ad() {
           log("onAdLoaded.")
           AdCache.cacheAd(
             adId = id,
-            ad = CacheAdModel.AppOpen(ad, Date().time),
+            ad = CachedAd.AppOpen(ad, Date().time),
           )
           onListener(AdEvent.AdLoaded)
         }
@@ -92,12 +92,11 @@ abstract class AppOpenAd : Ad() {
       return
     }
 
-    val appOpenAd = (ad as CacheAdModel.AppOpen).ad
+    val appOpenAd = (ad as CachedAd.AppOpen).ad
+
     if (!wasLoadTimeLessThanNHoursAgo(ad.loadTime, 4)) {
       reloadExpiredAd()
       return
-    } else {
-      log("App open ad is still valid; no need to reload.")
     }
 
     if (isShowing) {

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/AppOpenAd.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/AppOpenAd.kt
@@ -31,8 +31,6 @@ abstract class AppOpenAd : Ad() {
 
   override fun useCache() = false
 
-  private var loadTime: Long = 0
-
   override fun load(): Boolean {
     if (!super.load()) {
       return false
@@ -55,10 +53,9 @@ abstract class AppOpenAd : Ad() {
           log("onAdLoaded.")
           AdCache.cacheAd(
             adId = id,
-            ad = CacheAdModel.AppOpen(ad),
+            ad = CacheAdModel.AppOpen(ad, Date().time),
           )
           onListener(AdEvent.AdLoaded)
-          loadTime = Date().time
         }
 
         /**
@@ -95,14 +92,14 @@ abstract class AppOpenAd : Ad() {
       return
     }
 
-    if (!wasLoadTimeLessThanNHoursAgo(4)) {
+    val appOpenAd = (ad as CacheAdModel.AppOpen).ad
+    if (!wasLoadTimeLessThanNHoursAgo(ad.loadTime, 4)) {
       reloadExpiredAd()
       return
     } else {
       log("App open ad is still valid; no need to reload.")
     }
 
-    val appOpenAd = (ad as CacheAdModel.AppOpen).ad
     if (isShowing) {
       log("The app open ad is already showing.")
       return
@@ -152,9 +149,12 @@ abstract class AppOpenAd : Ad() {
     CurrentActivityHolder.activity?.let { appOpenAd.show(it) }
   }
 
-  private fun wasLoadTimeLessThanNHoursAgo(numHours: Long): Boolean {
-    val dateDifference: Long = Date().time - loadTime
-    val numMilliSecondsPerHour: Long = TimeUnit.HOURS.toMillis(1)
-    return dateDifference < numMilliSecondsPerHour * numHours
+  private fun wasLoadTimeLessThanNHoursAgo(
+    adLoadTime: Long,
+    hoursThreshold: Long,
+  ): Boolean {
+    val dateDifference: Long = Date().time - adLoadTime
+    val numMillisecondsPerHour: Long = TimeUnit.HOURS.toMillis(1)
+    return dateDifference < numMillisecondsPerHour * hoursThreshold
   }
 }

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/CacheAdModel.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/CacheAdModel.kt
@@ -22,10 +22,66 @@ import com.google.android.gms.ads.nativead.NativeAd
 import com.google.android.gms.ads.rewarded.RewardedAd
 import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
 
-sealed class CacheAdModel {
-  data class AppOpen(val ad: AppOpenAd) : CacheAdModel()
-  data class Interstitial(val ad: InterstitialAd) : CacheAdModel()
-  data class RewardedInterstitial(val ad: RewardedInterstitialAd) : CacheAdModel()
-  data class Rewarded(val ad: RewardedAd) : CacheAdModel()
-  data class Native(val ad: NativeAd) : CacheAdModel()
+/**
+ * Sealed class representing cached ad models with a load time.
+ *
+ * @property loadTime The time when the ad was loaded.
+ */
+sealed class CacheAdModel(
+  open val loadTime: Long,
+) {
+  /**
+   * Data class representing a cached App Open ad.
+   *
+   * @property ad The App Open ad instance.
+   * @property loadTime The time when the ad was loaded.
+   */
+  data class AppOpen(
+    val ad: AppOpenAd,
+    override val loadTime: Long,
+  ) : CacheAdModel(loadTime)
+
+  /**
+   * Data class representing a cached Interstitial ad.
+   *
+   * @property ad The Interstitial ad instance.
+   * @property loadTime The time when the ad was loaded.
+   */
+  data class Interstitial(
+    val ad: InterstitialAd,
+    override val loadTime: Long,
+  ) : CacheAdModel(loadTime)
+
+  /**
+   * Data class representing a cached Rewarded Interstitial ad.
+   *
+   * @property ad The Rewarded Interstitial ad instance.
+   * @property loadTime The time when the ad was loaded.
+   */
+  data class RewardedInterstitial(
+    val ad: RewardedInterstitialAd,
+    override val loadTime: Long,
+  ) : CacheAdModel(loadTime)
+
+  /**
+   * Data class representing a cached Rewarded ad.
+   *
+   * @property ad The Rewarded ad instance.
+   * @property loadTime The time when the ad was loaded.
+   */
+  data class Rewarded(
+    val ad: RewardedAd,
+    override val loadTime: Long,
+  ) : CacheAdModel(loadTime)
+
+  /**
+   * Data class representing a cached Native ad.
+   *
+   * @property ad The Native ad instance.
+   * @property loadTime The time when the ad was loaded.
+   */
+  data class Native(
+    val ad: NativeAd,
+    override val loadTime: Long,
+  ) : CacheAdModel(loadTime)
 }

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/CachedAd.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/CachedAd.kt
@@ -27,7 +27,7 @@ import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
  *
  * @property loadTime The time when the ad was loaded.
  */
-sealed class CacheAdModel(
+sealed class CachedAd(
   open val loadTime: Long,
 ) {
   /**
@@ -39,7 +39,7 @@ sealed class CacheAdModel(
   data class AppOpen(
     val ad: AppOpenAd,
     override val loadTime: Long,
-  ) : CacheAdModel(loadTime)
+  ) : CachedAd(loadTime)
 
   /**
    * Data class representing a cached Interstitial ad.
@@ -50,7 +50,7 @@ sealed class CacheAdModel(
   data class Interstitial(
     val ad: InterstitialAd,
     override val loadTime: Long,
-  ) : CacheAdModel(loadTime)
+  ) : CachedAd(loadTime)
 
   /**
    * Data class representing a cached Rewarded Interstitial ad.
@@ -61,7 +61,7 @@ sealed class CacheAdModel(
   data class RewardedInterstitial(
     val ad: RewardedInterstitialAd,
     override val loadTime: Long,
-  ) : CacheAdModel(loadTime)
+  ) : CachedAd(loadTime)
 
   /**
    * Data class representing a cached Rewarded ad.
@@ -72,7 +72,7 @@ sealed class CacheAdModel(
   data class Rewarded(
     val ad: RewardedAd,
     override val loadTime: Long,
-  ) : CacheAdModel(loadTime)
+  ) : CachedAd(loadTime)
 
   /**
    * Data class representing a cached Native ad.
@@ -83,5 +83,5 @@ sealed class CacheAdModel(
   data class Native(
     val ad: NativeAd,
     override val loadTime: Long,
-  ) : CacheAdModel(loadTime)
+  ) : CachedAd(loadTime)
 }

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/InterstitialAd.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/InterstitialAd.kt
@@ -23,6 +23,7 @@ import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.interstitial.InterstitialAd
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
 import dev.teogor.ceres.monetisation.admob.CurrentActivityHolder
+import java.util.Date
 
 abstract class InterstitialAd(
   loadAtInitialisation: Boolean = false,
@@ -57,7 +58,7 @@ abstract class InterstitialAd(
           log("Ad was loaded.")
           AdCache.cacheAd(
             adId = id,
-            ad = CacheAdModel.Interstitial(ad),
+            ad = CacheAdModel.Interstitial(ad, Date().time),
           )
           onListener(AdEvent.AdLoaded)
         }

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/InterstitialAd.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/InterstitialAd.kt
@@ -58,7 +58,7 @@ abstract class InterstitialAd(
           log("Ad was loaded.")
           AdCache.cacheAd(
             adId = id,
-            ad = CacheAdModel.Interstitial(ad, Date().time),
+            ad = CachedAd.Interstitial(ad, Date().time),
           )
           onListener(AdEvent.AdLoaded)
         }
@@ -84,7 +84,7 @@ abstract class InterstitialAd(
       load()
       return
     }
-    val interstitialAd = (ad as CacheAdModel.Interstitial).ad
+    val interstitialAd = (ad as CachedAd.Interstitial).ad
     if (isShowing) {
       log("The interstitial ad is already showing.")
       return

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/RewardedAd.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/RewardedAd.kt
@@ -23,6 +23,7 @@ import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.rewarded.RewardedAd
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
 import dev.teogor.ceres.monetisation.admob.CurrentActivityHolder
+import java.util.Date
 
 abstract class RewardedAd(
   loadAtInitialisation: Boolean = false,
@@ -57,7 +58,7 @@ abstract class RewardedAd(
           log("Ad was loaded.")
           AdCache.cacheAd(
             adId = id,
-            ad = CacheAdModel.Rewarded(ad),
+            ad = CacheAdModel.Rewarded(ad, Date().time),
           )
           onListener(AdEvent.AdLoaded)
         }

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/RewardedAd.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/RewardedAd.kt
@@ -58,7 +58,7 @@ abstract class RewardedAd(
           log("Ad was loaded.")
           AdCache.cacheAd(
             adId = id,
-            ad = CacheAdModel.Rewarded(ad, Date().time),
+            ad = CachedAd.Rewarded(ad, Date().time),
           )
           onListener(AdEvent.AdLoaded)
         }
@@ -84,7 +84,7 @@ abstract class RewardedAd(
       load()
       return
     }
-    val rewardedAd = (ad as CacheAdModel.Rewarded).ad
+    val rewardedAd = (ad as CachedAd.Rewarded).ad
     if (isShowing) {
       log("The rewarded interstitial ad is already showing.")
       return

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/RewardedInterstitialAd.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/RewardedInterstitialAd.kt
@@ -23,6 +23,7 @@ import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
 import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAdLoadCallback
 import dev.teogor.ceres.monetisation.admob.CurrentActivityHolder
+import java.util.Date
 
 abstract class RewardedInterstitialAd(
   loadAtInitialisation: Boolean = false,
@@ -57,7 +58,7 @@ abstract class RewardedInterstitialAd(
           log("Ad was loaded.")
           AdCache.cacheAd(
             adId = id,
-            ad = CacheAdModel.RewardedInterstitial(ad),
+            ad = CacheAdModel.RewardedInterstitial(ad, Date().time),
           )
           onListener(AdEvent.AdLoaded)
         }

--- a/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/RewardedInterstitialAd.kt
+++ b/monetisation/admob/src/main/kotlin/dev/teogor/ceres/monetisation/admob/formats/RewardedInterstitialAd.kt
@@ -58,7 +58,7 @@ abstract class RewardedInterstitialAd(
           log("Ad was loaded.")
           AdCache.cacheAd(
             adId = id,
-            ad = CacheAdModel.RewardedInterstitial(ad, Date().time),
+            ad = CachedAd.RewardedInterstitial(ad, Date().time),
           )
           onListener(AdEvent.AdLoaded)
         }
@@ -84,7 +84,7 @@ abstract class RewardedInterstitialAd(
       load()
       return
     }
-    val rewardedInterstitialAd = (ad as CacheAdModel.RewardedInterstitial).ad
+    val rewardedInterstitialAd = (ad as CachedAd.RewardedInterstitial).ad
     if (isShowing) {
       log("The rewarded interstitial ad is already showing.")
       return


### PR DESCRIPTION
### Description

This PR addresses multiple issues and introduces enhancements to the ad caching and loading system. The key commits included are:

#### 1. Fix Issue with Ads Not Reloading on Expiry Due to Incorrect Call

This commit resolves an issue where ads were not reloading upon expiry due to an incorrect call. It ensures that ads are now reloaded as expected, providing a seamless ad experience for users.

#### 2. Add `loadTime` Parameter to CacheAdModel Sealed Class

In this commit, we have introduced a new parameter, `loadTime`, to the `CacheAdModel` sealed class. This parameter offers crucial information about the ad's load time and enhances the data associated with cached ads.

#### 3. Rename `CacheAdModel` to `CachedAd`

The class `CacheAdModel` has been renamed to `CachedAd` for improved naming conventions and code readability.

These changes collectively improve the performance and maintainability of the ad caching and loading system.

### How to Use

You can continue to use the ad caching system as before, with the added benefit of improved ad reloading upon expiry and a clearer class name (`CachedAd`). Additionally, the `loadTime` parameter in `CachedAd` provides essential information about ad load times.

Closes #162 
