### PR TITLE
Fix Navigation Bar Padding Issue in Onboarding Screens

### DIFF
--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingRoute.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingRoute.kt
@@ -18,6 +18,7 @@ package dev.teogor.ceres.screen.ui.onboarding
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import dev.teogor.ceres.framework.core.app.BaseActions
@@ -67,7 +68,8 @@ internal fun OnboardingGraphBeta(
 
   Box(
     modifier = Modifier
-      .fillMaxSize(),
+      .fillMaxSize()
+      .navigationBarsPadding(),
   ) {
     when (screen) {
       OnboardingScreen.INTRO -> {


### PR DESCRIPTION
This pull request addresses a bug where the navigation bar padding was not being applied correctly to the onboarding screens. The issue has been resolved by adding the `.navigationBarsPadding()` modifier to the root `Box` component within the composable function.

**Bug Description:**

Previously, the onboarding screens displayed an unwanted gap at the bottom due to the default navigation bar padding.

**Solution:**

This pull request introduces the `.navigationBarsPadding()` modifier to the root `Box` component. This ensures that the content of the onboarding screens fills the entire available space, eliminating the gap at the bottom.