### PR TITLE
Enable Color Theme Picker Based on Dynamic Theming Support

### DIFF
--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/lookandfeel/LookAndFeelComponents.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/lookandfeel/LookAndFeelComponents.kt
@@ -305,7 +305,9 @@ fun ScreenListScope.lookAndFeelColorTheme() {
       preferenceFlow = ceresPreferences.getDisableDynamicThemingFlow(),
       initialValue = ceresPreferences.disableDynamicTheming,
     )
-    if (disableDynamicTheming) {
+    val showColorThemePicker = supportsDynamicTheming() && disableDynamicTheming ||
+      !supportsDynamicTheming()
+    if (showColorThemePicker) {
       SimpleView(
         title = Resources.LookAndFeelAppColorTheme,
         subtitle = Resources.LookAndFeelAppColorThemeSubtitle,


### PR DESCRIPTION
This pull request introduces an improvement to the logic that determines when to display the color theme picker. Previously, the picker only showed when `disableDynamicTheming` was true.

**Changes:**

- The condition for displaying the color theme picker has been expanded.
- The picker will now be shown in the following scenarios:
  - `supportsDynamicTheming()` returns `true` (dynamic theming is supported) **and** `disableDynamicTheming` is `true` (dynamic theming is disabled).
  - `supportsDynamicTheming()` returns `false` (dynamic theming is not supported).