### PR TITLE
Allow Customization of 'Get Started' Button in Onboarding Intro

### DIFF
--- a/app/src/main/kotlin/dev/teogor/ceres/feature/onboarding/OnboardingNavigation.kt
+++ b/app/src/main/kotlin/dev/teogor/ceres/feature/onboarding/OnboardingNavigation.kt
@@ -32,6 +32,8 @@ fun NavGraphBuilder.onboardingScreenNav(
   baseActions = baseActions,
   onboardingData = OnboardingScreenData(
     appName = "Ceres",
+    description = "Your Mobile framework",
+    getStartedButton = "GetStarted",
     supportEmail = "open-source@teogor.dev",
     privacyPolicyLink = "https://privacy.teogor.dev",
     termsOfServiceLink = "https://terms.teogor.dev",

--- a/screen/ui/api/ui.api
+++ b/screen/ui/api/ui.api
@@ -221,20 +221,22 @@ public final class dev/teogor/ceres/screen/ui/onboarding/OnboardingRoute : dev/t
 public final class dev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun areAllPermissionsGranted ()Z
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;
-	public static synthetic fun copy$default (Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;
+	public static synthetic fun copy$default (Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Ldev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppName ()Ljava/lang/String;
 	public final fun getDescription ()Ljava/lang/String;
+	public final fun getGetStartedButton ()Ljava/lang/String;
 	public final fun getPermissionCategories ()Ljava/util/List;
 	public final fun getPrivacyPolicyLink ()Ljava/lang/String;
 	public final fun getSupportEmail ()Ljava/lang/String;
@@ -312,13 +314,6 @@ public final class dev/teogor/ceres/screen/ui/onboarding/screens/ComposableSingl
 	public final fun getLambda-1$ui_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-2$ui_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-3$ui_release ()Lkotlin/jvm/functions/Function3;
-}
-
-public final class dev/teogor/ceres/screen/ui/onboarding/screens/ComposableSingletons$IntroScreenKt {
-	public static final field INSTANCE Ldev/teogor/ceres/screen/ui/onboarding/screens/ComposableSingletons$IntroScreenKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public fun <init> ()V
-	public final fun getLambda-1$ui_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class dev/teogor/ceres/screen/ui/onboarding/screens/ComposableSingletons$LegalScreenKt {

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/OnboardingScreenData.kt
@@ -25,6 +25,7 @@ data class OnboardingScreenData(
   val supportEmail: String = "%%SUPPORT_EMAIL%%",
   val privacyPolicyLink: String = "%%PRIVACY_POLICY_LINK%%",
   val termsOfServiceLink: String = "%%TERMS_OF_SERVICE_LINK%%",
+  val getStartedButton: String = "%%GET_STARTED%%",
   val permissionCategories: List<PermissionCategory> = listOf(PermissionCategory()),
 ) {
   fun areAllPermissionsGranted(): Boolean {

--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/IntroScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/onboarding/screens/IntroScreen.kt
@@ -111,7 +111,7 @@ fun BoxScope.IntroScreen(
         modifier = Modifier.padding(bottom = 30.dp),
       ) {
         Text(
-          text = "Get started",
+          text = data.getStartedButton,
           modifier = Modifier.padding(end = 10.dp, start = 10.dp),
         )
       }


### PR DESCRIPTION
**PR Description:**

This pull request introduces a new feature that allows customization of the "Get Started" button content within the onboarding intro section.

**Changes:**

- Implements functionality to modify the text displayed on the "Get Started" button in the onboarding intro.
- Provides a configuration option (`getStartedButton`) to specify the desired button text.
- Updates the onboarding intro UI to reflect the user-defined button content.

Closes #152 