### PR TITLE
Ensure Terms of Service Link Opens Correctly

### DIFF
--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/privacy/PrivacyScreen.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/privacy/PrivacyScreen.kt
@@ -300,7 +300,7 @@ fun ScreenListScope.termsOfServiceOption() = item {
     subtitle = Resources.ReviewOurTermsOfService,
     icon = Icons.Default.Link,
     clickable = {
-      applicationDetails.privacyLink?.let {
+      applicationDetails.termsLink?.let {
         uriHandler.openUri(it)
       }
     },


### PR DESCRIPTION
## Fix: Use Correct Link for Terms of Service Option

This pull request resolves an issue where the Terms of Service option was mistakenly opening the Privacy Policy link. The fix ensures the correct link is used.

**Problem:**

Previously, the `termsOfServiceOption()` function was incorrectly using `applicationDetails.privacyLink?.let { ... }` to open the Terms of Service page. This led users to the Privacy Policy instead.

**Solution:**

The code has been updated to use the correct property, `applicationDetails.termsLink?.let { ... }`, to ensure the Terms of Service page is opened as intended.

**Code Change:**

```kotlin
fun ScreenListScope.termsOfServiceOption() = item {
  val uriHandler = LocalUriHandler.current
  val applicationDetails = LocalApplicationDetails.current
  SimpleView(
    title = Resources.TermsOfService,
    subtitle = Resources.ReviewOurTermsOfService,
    icon = Icons.Default.Link,
    clickable = {
      applicationDetails.termsLink?.let {  // Corrected link property
        uriHandler.openUri(it)
      }
    },
  )
}
```