### PR TITLE
Introduce New Compose Icons for Diverse Use Cases

### DIFF
--- a/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/about/AboutComponents.kt
+++ b/screen/ui/src/main/kotlin/dev/teogor/ceres/screen/ui/about/AboutComponents.kt
@@ -29,14 +29,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.DateRange
-import androidx.compose.material.icons.filled.DomainVerification
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material.icons.filled.PermDeviceInformation
-import androidx.compose.material.icons.filled.Source
-import androidx.compose.material.icons.filled.Verified
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -64,6 +59,11 @@ import dev.teogor.ceres.screen.ui.res.Resources
 import dev.teogor.ceres.ui.designsystem.Surface
 import dev.teogor.ceres.ui.designsystem.Text
 import dev.teogor.ceres.ui.foundation.graphics.asImageVectorIcon
+import dev.teogor.ceres.ui.icons.automirrored.filled.OpenInNew
+import dev.teogor.ceres.ui.icons.filled.DomainVerification
+import dev.teogor.ceres.ui.icons.filled.PermDeviceInformation
+import dev.teogor.ceres.ui.icons.filled.Source
+import dev.teogor.ceres.ui.icons.filled.Verified
 import dev.teogor.ceres.ui.theme.MaterialTheme
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter

--- a/ui/icons/api/icons.api
+++ b/ui/icons/api/icons.api
@@ -23,3 +23,23 @@ public final class dev/teogor/ceres/ui/icons/CeresIcons {
 	public final fun getVolumeUp ()Landroidx/compose/ui/graphics/vector/ImageVector;
 }
 
+public final class dev/teogor/ceres/ui/icons/automirrored/filled/OpenInNewKt {
+	public static final fun getOpenInNew (Landroidx/compose/material/icons/Icons$AutoMirrored$Filled;)Landroidx/compose/ui/graphics/vector/ImageVector;
+}
+
+public final class dev/teogor/ceres/ui/icons/filled/DomainVerificationKt {
+	public static final fun getDomainVerification (Landroidx/compose/material/icons/Icons$Filled;)Landroidx/compose/ui/graphics/vector/ImageVector;
+}
+
+public final class dev/teogor/ceres/ui/icons/filled/PermDeviceInformationKt {
+	public static final fun getPermDeviceInformation (Landroidx/compose/material/icons/Icons$Filled;)Landroidx/compose/ui/graphics/vector/ImageVector;
+}
+
+public final class dev/teogor/ceres/ui/icons/filled/SourceKt {
+	public static final fun getSource (Landroidx/compose/material/icons/Icons$Filled;)Landroidx/compose/ui/graphics/vector/ImageVector;
+}
+
+public final class dev/teogor/ceres/ui/icons/filled/VerifiedKt {
+	public static final fun getVerified (Landroidx/compose/material/icons/Icons$Filled;)Landroidx/compose/ui/graphics/vector/ImageVector;
+}
+

--- a/ui/icons/src/main/kotlin/dev/teogor/ceres/ui/icons/automirrored/filled/OpenInNew.kt
+++ b/ui/icons/src/main/kotlin/dev/teogor/ceres/ui/icons/automirrored/filled/OpenInNew.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.ui.icons.automirrored.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+@Suppress("UnusedReceiverParameter")
+val Icons.AutoMirrored.Filled.OpenInNew: ImageVector
+  get() {
+    if (_openInNew != null) {
+      return _openInNew!!
+    }
+    _openInNew = materialIcon(name = "AutoMirrored.Filled.OpenInNew", autoMirror = true) {
+      materialPath {
+        moveTo(19.0f, 19.0f)
+        horizontalLineTo(5.0f)
+        verticalLineTo(5.0f)
+        horizontalLineToRelative(7.0f)
+        verticalLineTo(3.0f)
+        horizontalLineTo(5.0f)
+        curveToRelative(-1.11f, 0.0f, -2.0f, 0.9f, -2.0f, 2.0f)
+        verticalLineToRelative(14.0f)
+        curveToRelative(0.0f, 1.1f, 0.89f, 2.0f, 2.0f, 2.0f)
+        horizontalLineToRelative(14.0f)
+        curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+        verticalLineToRelative(-7.0f)
+        horizontalLineToRelative(-2.0f)
+        verticalLineToRelative(7.0f)
+        close()
+        moveTo(14.0f, 3.0f)
+        verticalLineToRelative(2.0f)
+        horizontalLineToRelative(3.59f)
+        lineToRelative(-9.83f, 9.83f)
+        lineToRelative(1.41f, 1.41f)
+        lineTo(19.0f, 6.41f)
+        verticalLineTo(10.0f)
+        horizontalLineToRelative(2.0f)
+        verticalLineTo(3.0f)
+        horizontalLineToRelative(-7.0f)
+        close()
+      }
+    }
+    return _openInNew!!
+  }
+
+private var _openInNew: ImageVector? = null

--- a/ui/icons/src/main/kotlin/dev/teogor/ceres/ui/icons/filled/DomainVerification.kt
+++ b/ui/icons/src/main/kotlin/dev/teogor/ceres/ui/icons/filled/DomainVerification.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.ui.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+@Suppress("UnusedReceiverParameter")
+val Icons.Filled.DomainVerification: ImageVector
+  get() {
+    if (_domainVerification != null) {
+      return _domainVerification!!
+    }
+    _domainVerification = materialIcon(name = "Filled.DomainVerification") {
+      materialPath {
+        moveTo(16.6f, 10.88f)
+        lineToRelative(-1.42f, -1.42f)
+        lineToRelative(-4.24f, 4.25f)
+        lineToRelative(-2.12f, -2.13f)
+        lineToRelative(-1.42f, 1.42f)
+        lineToRelative(3.54f, 3.54f)
+        close()
+      }
+      materialPath {
+        moveTo(19.0f, 4.0f)
+        horizontalLineTo(5.0f)
+        curveTo(3.89f, 4.0f, 3.0f, 4.9f, 3.0f, 6.0f)
+        verticalLineToRelative(12.0f)
+        curveToRelative(0.0f, 1.1f, 0.89f, 2.0f, 2.0f, 2.0f)
+        horizontalLineToRelative(14.0f)
+        curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+        verticalLineTo(6.0f)
+        curveTo(21.0f, 4.9f, 20.11f, 4.0f, 19.0f, 4.0f)
+        close()
+        moveTo(19.0f, 18.0f)
+        horizontalLineTo(5.0f)
+        verticalLineTo(8.0f)
+        horizontalLineToRelative(14.0f)
+        verticalLineTo(18.0f)
+        close()
+      }
+    }
+    return _domainVerification!!
+  }
+
+private var _domainVerification: ImageVector? = null

--- a/ui/icons/src/main/kotlin/dev/teogor/ceres/ui/icons/filled/PermDeviceInformation.kt
+++ b/ui/icons/src/main/kotlin/dev/teogor/ceres/ui/icons/filled/PermDeviceInformation.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.ui.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+@Suppress("UnusedReceiverParameter")
+val Icons.Filled.PermDeviceInformation: ImageVector
+  get() {
+    if (_permDeviceInformation != null) {
+      return _permDeviceInformation!!
+    }
+    _permDeviceInformation = materialIcon(name = "Filled.PermDeviceInformation") {
+      materialPath {
+        moveTo(13.0f, 7.0f)
+        horizontalLineToRelative(-2.0f)
+        verticalLineToRelative(2.0f)
+        horizontalLineToRelative(2.0f)
+        lineTo(13.0f, 7.0f)
+        close()
+        moveTo(13.0f, 11.0f)
+        horizontalLineToRelative(-2.0f)
+        verticalLineToRelative(6.0f)
+        horizontalLineToRelative(2.0f)
+        verticalLineToRelative(-6.0f)
+        close()
+        moveTo(17.0f, 1.01f)
+        lineTo(7.0f, 1.0f)
+        curveToRelative(-1.1f, 0.0f, -2.0f, 0.9f, -2.0f, 2.0f)
+        verticalLineToRelative(18.0f)
+        curveToRelative(0.0f, 1.1f, 0.9f, 2.0f, 2.0f, 2.0f)
+        horizontalLineToRelative(10.0f)
+        curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+        lineTo(19.0f, 3.0f)
+        curveToRelative(0.0f, -1.1f, -0.9f, -1.99f, -2.0f, -1.99f)
+        close()
+        moveTo(17.0f, 19.0f)
+        lineTo(7.0f, 19.0f)
+        lineTo(7.0f, 5.0f)
+        horizontalLineToRelative(10.0f)
+        verticalLineToRelative(14.0f)
+        close()
+      }
+    }
+    return _permDeviceInformation!!
+  }
+
+private var _permDeviceInformation: ImageVector? = null

--- a/ui/icons/src/main/kotlin/dev/teogor/ceres/ui/icons/filled/Source.kt
+++ b/ui/icons/src/main/kotlin/dev/teogor/ceres/ui/icons/filled/Source.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.ui.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+@Suppress("UnusedReceiverParameter")
+val Icons.Filled.Source: ImageVector
+  get() {
+    if (_source != null) {
+      return _source!!
+    }
+    _source = materialIcon(name = "Filled.Source") {
+      materialPath {
+        moveTo(20.0f, 6.0f)
+        horizontalLineToRelative(-8.0f)
+        lineToRelative(-2.0f, -2.0f)
+        horizontalLineTo(4.0f)
+        curveTo(2.9f, 4.0f, 2.01f, 4.9f, 2.01f, 6.0f)
+        lineTo(2.0f, 18.0f)
+        curveToRelative(0.0f, 1.1f, 0.9f, 2.0f, 2.0f, 2.0f)
+        horizontalLineToRelative(16.0f)
+        curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+        verticalLineTo(8.0f)
+        curveTo(22.0f, 6.9f, 21.1f, 6.0f, 20.0f, 6.0f)
+        close()
+        moveTo(14.0f, 16.0f)
+        horizontalLineTo(6.0f)
+        verticalLineToRelative(-2.0f)
+        horizontalLineToRelative(8.0f)
+        verticalLineTo(16.0f)
+        close()
+        moveTo(18.0f, 12.0f)
+        horizontalLineTo(6.0f)
+        verticalLineToRelative(-2.0f)
+        horizontalLineToRelative(12.0f)
+        verticalLineTo(12.0f)
+        close()
+      }
+    }
+    return _source!!
+  }
+
+private var _source: ImageVector? = null

--- a/ui/icons/src/main/kotlin/dev/teogor/ceres/ui/icons/filled/Verified.kt
+++ b/ui/icons/src/main/kotlin/dev/teogor/ceres/ui/icons/filled/Verified.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.ceres.ui.icons.filled
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+@Suppress("UnusedReceiverParameter")
+val Icons.Filled.Verified: ImageVector
+  get() {
+    if (_verified != null) {
+      return _verified!!
+    }
+    _verified = materialIcon(name = "Filled.Verified") {
+      materialPath {
+        moveTo(23.0f, 12.0f)
+        lineToRelative(-2.44f, -2.79f)
+        lineToRelative(0.34f, -3.69f)
+        lineToRelative(-3.61f, -0.82f)
+        lineTo(15.4f, 1.5f)
+        lineTo(12.0f, 2.96f)
+        lineTo(8.6f, 1.5f)
+        lineTo(6.71f, 4.69f)
+        lineTo(3.1f, 5.5f)
+        lineTo(3.44f, 9.2f)
+        lineTo(1.0f, 12.0f)
+        lineToRelative(2.44f, 2.79f)
+        lineToRelative(-0.34f, 3.7f)
+        lineToRelative(3.61f, 0.82f)
+        lineTo(8.6f, 22.5f)
+        lineToRelative(3.4f, -1.47f)
+        lineToRelative(3.4f, 1.46f)
+        lineToRelative(1.89f, -3.19f)
+        lineToRelative(3.61f, -0.82f)
+        lineToRelative(-0.34f, -3.69f)
+        lineTo(23.0f, 12.0f)
+        close()
+        moveTo(10.09f, 16.72f)
+        lineToRelative(-3.8f, -3.81f)
+        lineToRelative(1.48f, -1.48f)
+        lineToRelative(2.32f, 2.33f)
+        lineToRelative(5.85f, -5.87f)
+        lineToRelative(1.48f, 1.48f)
+        lineTo(10.09f, 16.72f)
+        close()
+      }
+    }
+    return _verified!!
+  }
+
+private var _verified: ImageVector? = null


### PR DESCRIPTION
## Introduce New Compose Icons

This pull request introduces a set of new icons for utilization within your Compose applications:

- `OpenInNew`: Represents opening content in a new window or tab.
- `DomainVerification`:  Indicates domain verification for security purposes.
- `PermDeviceInformation`:  Represents device information permissions.
- `Source`:  Icon for source or origin.
- `Verified`:  Signifies verification status.

**Benefits:**

- **Enhanced User Experience:** Provides developers with a wider range of icons to visually represent various concepts within their applications.
- **Improved UI Consistency:**  Contributes to a consistent and clear visual language throughout the application.
- **Expanded Design Options:**  Empowers developers to create more engaging and informative user interfaces.

**Implementation:**

These new icons are implemented as Compose composables, following established guidelines for consistent design and usage.