### PR TITLE
Focus Dokka Multi-Module on Relevant Modules (Exclude bom & app)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -222,8 +222,13 @@ subprojects {
 }
 
 tasks.dokkaHtmlMultiModule {
-  childProjects.values.forEach {
-    dependsOn(":${it.name}:dokkaHtmlMultiModule")
+  childProjects.values.map {
+    it.name
+  }.filter {
+    it != "app" && it != "bom"
+  }.forEach {
+    val taskPath = ":${it}:dokkaHtmlMultiModule"
+    dependsOn(taskPath)
   }
 }
 


### PR DESCRIPTION
## Optimized DokkaHtmlMultiModule Task Execution

This pull request refines the execution of the `dokkaHtmlMultiModule` task to generate documentation only for desired modules within the project.

**Previous Approach:**

Previously, the code relied on the following logic:

```
tasks.dokkaHtmlMultiModule {
  childProjects.values.forEach {
    dependsOn(":${it.name}:dokkaHtmlMultiModule")
  }
}
```

This approach triggered the `dokkaHtmlMultiModule` task for all child projects, potentially generating documentation for modules that don't require it (e.g., BOM or application module).

**Updated Approach:**

The code has been updated to selectively execute the task for specific modules:

```
tasks.dokkaHtmlMultiModule {
  childProjects.values.map { it.name }.filter {
    it != "app" && it != "bom"
  }.forEach {
    val taskPath = ":${it}:dokkaHtmlMultiModule"
    dependsOn(taskPath)
  }
}
```

This revised approach:

- Filters out the "app" and "bom" modules from the processing list.
- Generates documentation only for the remaining child projects.

**Benefits:**

- Improved build efficiency by excluding unnecessary documentation generation.
- Reduced build time by focusing on relevant modules.
- Streamlined documentation process.